### PR TITLE
Adding support for Base91 encoded telemetry.

### DIFF
--- a/lib/MessageModels/MICEPosition.js
+++ b/lib/MessageModels/MICEPosition.js
@@ -106,17 +106,44 @@ MICEPosition.prototype.getAltitudeFromMICE = function (comment) {
     let altitude;
     let msgString = comment.substr(0, 5).match(/(...)}/);  //Alt is in the format XXX}  where XXX = base91 encoded altitude in meters
     if (msgString && msgString[1]) {
-        let value = 0;
-        for (let i = 0; i < msgString[1].length; i++) {
-            value = value * 91 + msgString[1].charCodeAt(i) - 33;
-        }
+        var value = parseBase91(msgString[1]);
         altitude = value - 10000;
     }
     if (altitude) {
         this.altitude = altitude;
         this.comment = comment.substr(comment.indexOf('}') + 1);  //Remove altitude info from comment
     }
+
+    return this.comment;
 };
+
+MICEPosition.prototype.getBase91TelemFromMICE = function (comment) {
+    //Theoretically, this finds the TM sequence
+    //This should be a sequence number, 1-5 TM values, and a pair for binary values (which can only appear if 5 other values are sent)
+    //I'm not sure if there's a better thing to try and match in the middle? This is based on what the Python aprslib did
+    //let msgString = comment.match(/\|(\S\S){1,7}\|/g);
+    let msgString = comment.match(/(.*)\|([!-{]{4,14})\|(.*)/);
+    if (msgString && msgString[2]) { //Found something. [2] is the TM data itself
+        this.comment = this.comment.replace('|' + msgString[2] + '|',''); //Remove the TM block from the comment. Need to add the pipes back. Regex stripped them.
+        this.telemetrySequence = parseBase91(msgString[2].substring(0,2));
+        let tmValues = msgString[2].substring(2);
+        this.telemetryValues = []; //Put an array on here
+        while (tmValues.length > 0) {
+            this.telemetryValues.push(parseBase91(tmValues.substring(0,2)));
+            tmValues = tmValues.substring(2);
+        }
+    }
+
+    return this.comment;
+};
+
+function parseBase91(msgString) {
+    let value = 0;
+    for (let i = 0; i < msgString.length; i++) {
+        value = value * 91 + msgString.charCodeAt(i) - 33;
+    }
+    return value;
+}
 
 MICEPosition.State = {
     "M0": "off duty",

--- a/lib/Position/MICEParser.js
+++ b/lib/Position/MICEParser.js
@@ -38,8 +38,11 @@ MICEParser.prototype.tryParse = function (bodyContent, aprsMessageHeader) {
         comment = position.setRadio(comment);
         position.setComment(comment);
 
-        //altitude form mice overwrite altitude parsed from comment
-        position.getAltitudeFromMICE(comment);
+        //altitude from mice overwrite altitude parsed from comment
+        comment = position.getAltitudeFromMICE(comment);
+
+        //Check for and parse base91 telemetry (if present)
+        comment = position.getBase91TelemFromMICE(comment);
     }
     return position;
 };


### PR DESCRIPTION
I don't know if you're interested in it or not, but I took a shot at parsing out the compressed comment telemetry format that some trackers use. I've tried it with packets from my TinyTrak3, but that's all I've got access to.