### PR TITLE
Added support for new message ACK request format

### DIFF
--- a/lib/Message/MessageParser.js
+++ b/lib/Message/MessageParser.js
@@ -22,7 +22,7 @@ var tryParseMsgId = function (messageBody) {
             throw new Error("Wrong message id?");
         }
         else {
-            return {content: messageBody.substr(0, posId), id: parseInt(idString)};
+            return {content: messageBody.substr(0, posId), id: idString};
         }
     }
 };

--- a/lib/Message/MessageParser.js
+++ b/lib/Message/MessageParser.js
@@ -15,7 +15,10 @@ var tryParseMsgId = function (messageBody) {
         return {content: messageBody};
     } else {
         var idString = messageBody.substr(posId + 1);
-        if (!idString.match("^[0-9]{1,5}")) {
+        if (idString.endsWith('}')) {
+            idString = idString.substr(0, idString.length - 1);
+        }
+        if (!idString.match("^[0-9a-zA-Z]{1,5}")) {
             throw new Error("Wrong message id?");
         }
         else {


### PR DESCRIPTION
New packet radios sometime use the new ACK request format which is `{XXXXX}`
Just like the old format, there can be up to 5 characters BUT they can also be alphanumeric
To signal the received that the message uses the newer format, a `}` us appended to the end.