### PR TITLE
var to let/const, double quote to single

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,7 +31,6 @@ module.exports = {
         'no-undef': ['error'],
         'no-console':0,
         'prefer-const': 'warn',
-        //'object-shorthand': ['warn', 'always'],
         'quotes': ['error', 'single'],
         'prefer-arrow-callback': ['warn', { 'allowNamedFunctions': true }],
         'no-trailing-spaces':['error'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,40 @@
+module.exports = {
+    'env': {
+        'es6': true,
+        'node': true,
+        'commonjs': true,
+        'mocha': true
+    },
+    'extends': 'eslint:recommended',
+    'parserOptions': {
+        'sourceType': 'module',
+        'ecmaVersion': 2018
+    },
+    'globals':{
+    },
+    'rules': {
+        'indent': [
+            'warn',
+            4,
+            {'SwitchCase': 1}
+        ],
+        'linebreak-style': [
+            'error',
+            'unix'
+        ],
+        'semi': [
+            'error',
+            'always'
+        ],
+        'no-unused-vars':0,
+        'no-empty':0,
+        'no-undef': ['error'],
+        'no-console':0,
+        'prefer-const': 'warn',
+        //'object-shorthand': ['warn', 'always'],
+        'quotes': ['error', 'single'],
+        'prefer-arrow-callback': ['warn', { 'allowNamedFunctions': true }],
+        'no-trailing-spaces':['error'],
+        'callback-return': ['warn'],
+    }
+};

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - npm run lint
   - "node"
-
+script:
+  - npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
+  - npm run lint
   - "node"
+

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ JavaScript library for parsing [APRS](http://www.aprs.org/) packets.
 ## Code Example
 
 ```javascript
-    var aprs = require("aprs-parser");
+    const aprs = require("aprs-parser");
     
-    var parser = new aprs.APRSParser();
+    const parser = new aprs.APRSParser();
 
     console.log(parser.parse("SQ7PFS-10>APRS,TCPIP*,qAC,T2SYDNEY:@085502h4903.50N/07201.75W-PHG5132Hello world/A=001234"));
     console.log();

--- a/lib/APRSISConnector.js
+++ b/lib/APRSISConnector.js
@@ -1,30 +1,29 @@
 'use strict';
 
-var util = require("util");
-var net = require('net');
+const net = require('net');
 const readline = require('readline');
-var EventEmitter = require("events").EventEmitter;
+const EventEmitter = require('events').EventEmitter;
 
-var APRSParser = require("./APRSParser");
+const APRSParser = require('./APRSParser');
 
 const APRSServer = 'rotate.aprs2.net';
 const APRSPort = 10152;
 
 function APRSISConnector() {
-    var that = this;
-    var parser = new APRSParser();
+    const that = this;
+    const parser = new APRSParser();
 
-    this.on("raw", function (line) {
-        var parsed = parser.parse(line);
-        that.emit("aprs", parsed);
+    this.on('raw', (line) => {
+        const parsed = parser.parse(line);
+        that.emit('aprs', parsed);
 
         if (parsed.data)
-            that.emit("aprs-success", parsed);
+            that.emit('aprs-success', parsed);
         else {
             if (parsed.errors)
-                that.emit("aprs-failure", parsed);
+                that.emit('aprs-failure', parsed);
             else
-                that.emit("aprs-unknown", parsed);
+                that.emit('aprs-unknown', parsed);
         }
     });
 }
@@ -38,31 +37,31 @@ APRSISConnector.prototype.connect = function (callsign) {
     }
 
     this.client = new net.Socket();
-    this.client.setEncoding("utf-8");
-    var that = this;
+    this.client.setEncoding('utf-8');
+    const that = this;
 
     const rl = readline.createInterface({
         input: this.client
     });
 
-    rl.on("line", function (line) {
-        if (!line.startsWith("#"))
-            that.emit("raw", line)
+    rl.on('line', (line) => {
+        if (!line.startsWith('#'))
+            that.emit('raw', line);
     });
 
-    that.client.connect(APRSPort, APRSServer, function () {
-        that.client.write("user " + callsign + "\n");
-        that.emit("connected");
+    that.client.connect(APRSPort, APRSServer, () => {
+        that.client.write('user ' + callsign + '\n');
+        that.emit('connected');
     });
 
-    that.client.on("close", function () {
-        that.emit("disconnected");
-    })
+    that.client.on('close', () => {
+        that.emit('disconnected');
+    });
 };
 
 APRSISConnector.prototype.disconnect = function () {
     this.client.end();
-    this.emit("disconnected");
+    this.emit('disconnected');
 };
 
 module.exports = APRSISConnector;

--- a/lib/APRSParser.js
+++ b/lib/APRSParser.js
@@ -1,30 +1,30 @@
 'use strict';
 
-var APRSMessage = require("./APRSMessage.js");
-var Callsign = require("./Callsign.js");
+const APRSMessage = require('./APRSMessage.js');
+const Callsign = require('./Callsign.js');
 
-var PositionParser = require("./Position/PositionParser.js");
-var MessageParser = require("./Message/MessageParser.js");
-var TelemetryParser = require("./Telemetry/TelemetryParser.js");
-var TelemetryDescriptionParser = require("./Telemetry/TelemetryDescriptionParser.js");
-var MICEParser = require("./Position/MICEParser.js");
-var ObjectParser = require("./Object/ObjectParser.js");
-var StatusReportParser = require("./StatusReport/StatusReportParser.js");
+const PositionParser = require('./Position/PositionParser.js');
+const MessageParser = require('./Message/MessageParser.js');
+const TelemetryParser = require('./Telemetry/TelemetryParser.js');
+const TelemetryDescriptionParser = require('./Telemetry/TelemetryDescriptionParser.js');
+const MICEParser = require('./Position/MICEParser.js');
+const ObjectParser = require('./Object/ObjectParser.js');
+const StatusReportParser = require('./StatusReport/StatusReportParser.js');
 
-var parseHeader = function (messageHeaderString, messageObject) {
-    var destinationDelimiterPos = messageHeaderString.indexOf(">");
+const parseHeader = function (messageHeaderString, messageObject) {
+    const destinationDelimiterPos = messageHeaderString.indexOf('>');
 
     if (destinationDelimiterPos < 0) {
-        throw new Error("Malformed header");
+        throw new Error('Malformed header');
     }
 
-    var fromCallsignString = messageHeaderString.substr(0, destinationDelimiterPos);
+    const fromCallsignString = messageHeaderString.substr(0, destinationDelimiterPos);
 
-    var toAndDigiString = messageHeaderString.substr(destinationDelimiterPos + 1);
-    var toAndDigiDelimiterPos = toAndDigiString.indexOf(",");
+    const toAndDigiString = messageHeaderString.substr(destinationDelimiterPos + 1);
+    const toAndDigiDelimiterPos = toAndDigiString.indexOf(',');
 
-    var toCallsignString = "";
-    var digiArray = [];
+    let toCallsignString = '';
+    let digiArray = [];
 
     if (toAndDigiDelimiterPos < 0) {
         toCallsignString = toAndDigiString;
@@ -35,7 +35,7 @@ var parseHeader = function (messageHeaderString, messageObject) {
         digiArray = toAndDigiString.substr(toAndDigiDelimiterPos + 1).split(',');
     }
 
-    messageObject.setHeaderInfo(new Callsign(fromCallsignString), new Callsign(toCallsignString), digiArray.map(function (obj) {
+    messageObject.setHeaderInfo(new Callsign(fromCallsignString), new Callsign(toCallsignString), digiArray.map((obj) => {
         return new Callsign(obj);
     }));
 
@@ -56,41 +56,41 @@ function APRSParser() {
 }
 
 APRSParser.prototype.parse = function (messageContent) {
-    var aprsMessage = new APRSMessage();
+    let aprsMessage = new APRSMessage();
     aprsMessage.setRawData(messageContent);
-    var errors = [];
+    const errors = [];
 
     try {
-        var headerDelimiterPos = messageContent.indexOf(":");
+        const headerDelimiterPos = messageContent.indexOf(':');
 
         if (headerDelimiterPos < 0) {
-            throw new Error("Header - body delimiter not found");
+            throw new Error('Header - body delimiter not found');
         }
 
-        var messageBodyString = messageContent.substr(headerDelimiterPos + 1);
-        var messageHeaderString = messageContent.substr(0, headerDelimiterPos);
+        const messageBodyString = messageContent.substr(headerDelimiterPos + 1);
+        const messageHeaderString = messageContent.substr(0, headerDelimiterPos);
 
         aprsMessage = parseHeader(messageHeaderString, aprsMessage);
 
-        for (var i = 0; i < this.parsers.length; i++) {
-            var parser = this.parsers[i];
+        for (let i = 0; i < this.parsers.length; i++) {
+            const parser = this.parsers[i];
 
             if (parser.isMatching(messageBodyString)) {
                 try {
-                    var data = parser.tryParse(messageBodyString, aprsMessage);
+                    const data = parser.tryParse(messageBodyString, aprsMessage);
 
                     if (data) {
                         aprsMessage.setBody(data);
                     }
                 }
                 catch (ex) {
-                    errors.push(parser.getParserName() + ": " + ex.toString());
+                    errors.push(parser.getParserName() + ': ' + ex.toString());
                 }
             }
         }
     }
     catch (ex) {
-        errors.push("General: " + ex.toString());
+        errors.push('General: ' + ex.toString());
     }
 
     if (!aprsMessage.data && errors.length != 0)

--- a/lib/AbstractParser.js
+++ b/lib/AbstractParser.js
@@ -1,19 +1,19 @@
 function AbstractParser() {
     if (this.constructor === AbstractParser) {
-        throw new Error("Can't instantiate abstract class!");
+        throw new Error('Can\'t instantiate abstract class!');
     }
 }
 
 AbstractParser.prototype.isMatching = function (bodyContent) {
-    throw new Error("Abstract method!");
+    throw new Error('Abstract method!');
 };
 
 AbstractParser.prototype.tryParse = function (bodyContent, aprsMessageHeader) {
-    throw new Error("Abstract method!");
+    throw new Error('Abstract method!');
 };
 
 AbstractParser.prototype.getParserName = function () {
-    throw new Error("Abstract method!");
+    throw new Error('Abstract method!');
 };
 
 module.exports = AbstractParser;

--- a/lib/Callsign.js
+++ b/lib/Callsign.js
@@ -1,24 +1,24 @@
 'use strict';
 
-var checkAndParseCallsign = function (callsign) {
+const checkAndParseCallsign = function (callsign) {
     return callsign;
 };
 
 function Callsign(callsignString) {
-    var ssidDelimPos = callsignString.indexOf("-");
+    let ssidDelimPos = callsignString.indexOf('-');
 
     if (ssidDelimPos == 0) {
-        throw new Error("Empty callsign (only SSID)?");
+        throw new Error('Empty callsign (only SSID)?');
     }
 
     if (ssidDelimPos < 0) {
         ssidDelimPos = callsignString.length;
     }
     else {
-        var ssidString = callsignString.substr(ssidDelimPos + 1);
+        const ssidString = callsignString.substr(ssidDelimPos + 1);
 
         if (ssidString.length < 1) {
-            throw new Error("Malformed SSID");
+            throw new Error('Malformed SSID');
         }
 
         this.ssid = ssidString;
@@ -28,7 +28,7 @@ function Callsign(callsignString) {
 }
 
 Callsign.prototype.toString = function () {
-    return this.call + (this.ssid ? ("-" + this.ssid) : "");
+    return this.call + (this.ssid ? ('-' + this.ssid) : '');
 };
 
 module.exports = Callsign;

--- a/lib/Message/MessageParser.js
+++ b/lib/Message/MessageParser.js
@@ -1,22 +1,22 @@
 'use strict';
-var AbstractParser = require("../AbstractParser.js");
+const AbstractParser = require('../AbstractParser.js');
 
-var Callsign = require("../Callsign.js");
-var Message = require("./../MessageModels/Message.js");
+const Callsign = require('../Callsign.js');
+const Message = require('./../MessageModels/Message.js');
 
 function MessageParser() {
 
 }
 
-var tryParseMsgId = function (messageBody) {
-    var posId = messageBody.indexOf("{");
+const tryParseMsgId = function (messageBody) {
+    const posId = messageBody.indexOf('{');
 
     if (posId < 0) {
         return {content: messageBody};
     } else {
-        var idString = messageBody.substr(posId + 1);
-        if (!idString.match("^[0-9]{1,5}")) {
-            throw new Error("Wrong message id?");
+        const idString = messageBody.substr(posId + 1);
+        if (!idString.match('^[0-9]{1,5}')) {
+            throw new Error('Wrong message id?');
         }
         else {
             return {content: messageBody.substr(0, posId), id: parseInt(idString)};
@@ -28,35 +28,35 @@ MessageParser.constructor = MessageParser;
 MessageParser.prototype = Object.create(AbstractParser.prototype);
 
 MessageParser.prototype.isMatching = function (bodyContent) {
-    return bodyContent[0] == ":";
+    return bodyContent[0] == ':';
 };
 
 MessageParser.prototype.tryParse = function (bodyContent, aprsMessageHeader) {
-    var addressee = new Callsign(bodyContent.substr(1, 9).trim());
-    var message = new Message(addressee);
+    const addressee = new Callsign(bodyContent.substr(1, 9).trim());
+    const message = new Message(addressee);
 
-    if (bodyContent[10] != ":") {
-        throw Error("Wrong message format");
+    if (bodyContent[10] != ':') {
+        throw Error('Wrong message format');
     }
 
     //remove :9 characters:
-    var messageBody = bodyContent.substr(11);
+    const messageBody = bodyContent.substr(11);
 
-    if (messageBody.startsWith("ack") || messageBody.startsWith("rej")) {
-        var ackRejIdString = messageBody.substr(3);
-        if (!ackRejIdString.match("^[0-9]{1,5}")) {
-            throw new Error("Wrong ACK/REJ id?");
+    if (messageBody.startsWith('ack') || messageBody.startsWith('rej')) {
+        const ackRejIdString = messageBody.substr(3);
+        if (!ackRejIdString.match('^[0-9]{1,5}')) {
+            throw new Error('Wrong ACK/REJ id?');
         }
 
         message.setId(parseInt(ackRejIdString));
 
-        if (messageBody.startsWith("ack"))
+        if (messageBody.startsWith('ack'))
             message.setToAck();
         else
             message.setToRej();
     }
     else {
-        var parsedMessage = tryParseMsgId(messageBody);
+        const parsedMessage = tryParseMsgId(messageBody);
         message.setText(parsedMessage.content);
 
         if (parsedMessage.id)
@@ -67,7 +67,7 @@ MessageParser.prototype.tryParse = function (bodyContent, aprsMessageHeader) {
 };
 
 MessageParser.prototype.getParserName = function () {
-    return "MessageParser";
+    return 'MessageParser';
 };
 
 module.exports = MessageParser;

--- a/lib/MessageModels/MICEPosition.js
+++ b/lib/MessageModels/MICEPosition.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var Position = require("./Position.js");
+const Position = require('./Position.js');
 
 const radioLookupDict = {
-    prefixes: [">", "]", "`", "'"],
+    prefixes: ['>', ']', '`', '\''],
 
     //Ref:  http://www.aprs.org/aprs12/mic-e-types.txt
     lookups: [
@@ -116,12 +116,12 @@ MICEPosition.prototype.setRadio = function (message) {
     if (radioLookupDict.prefixes.indexOf(message.substr(0, 1)) > -1) {
         radioLookupDict.lookups.forEach((radio) => {
             if (message.substr(0, 1) == radio.prefix && message.substr(0 - radio.suffix.length) == radio.suffix
-    )
-        {
-            this.radio = radio.name; //Set radio name
-            message = message.substr(radio.prefix.length, message.length - radio.suffix.length - 1);  //Remove radio designators from comment
-        }
-    })
+            )
+            {
+                this.radio = radio.name; //Set radio name
+                message = message.substr(radio.prefix.length, message.length - radio.suffix.length - 1);  //Remove radio designators from comment
+            }
+        })
         ;
     }
     return message;
@@ -129,7 +129,7 @@ MICEPosition.prototype.setRadio = function (message) {
 
 MICEPosition.prototype.getAltitudeFromMICE = function (comment) {
     let altitude;
-    let msgString = comment.substr(0, 5).match(/(...)}/);  //Alt is in the format XXX}  where XXX = base91 encoded altitude in meters
+    const msgString = comment.substr(0, 5).match(/(...)}/);  //Alt is in the format XXX}  where XXX = base91 encoded altitude in meters
     if (msgString && msgString[1]) {
         let value = 0;
         for (let i = 0; i < msgString[1].length; i++) {
@@ -144,22 +144,22 @@ MICEPosition.prototype.getAltitudeFromMICE = function (comment) {
 };
 
 MICEPosition.State = {
-    "M0": "off duty",
-    "M1": "en route",
-    "M2": "in service",
-    "M3": "returning",
-    "M4": "commited",
-    "M5": "special",
-    "M6": "priority",
-    "C0": "custom-0",
-    "C1": "custom-1",
-    "C2": "custom-2",
-    "C3": "custom-3",
-    "C4": "custom-4",
-    "C5": "custom-5",
-    "C6": "custom-6",
-    "EMERGENCY": "emergency",
-    "UNKNOWN": "unknown"
+    'M0': 'off duty',
+    'M1': 'en route',
+    'M2': 'in service',
+    'M3': 'returning',
+    'M4': 'commited',
+    'M5': 'special',
+    'M6': 'priority',
+    'C0': 'custom-0',
+    'C1': 'custom-1',
+    'C2': 'custom-2',
+    'C3': 'custom-3',
+    'C4': 'custom-4',
+    'C5': 'custom-5',
+    'C6': 'custom-6',
+    'EMERGENCY': 'emergency',
+    'UNKNOWN': 'unknown'
 };
 
 module.exports = MICEPosition;

--- a/lib/MessageModels/Message.js
+++ b/lib/MessageModels/Message.js
@@ -23,6 +23,6 @@ Message.prototype.setToRej = function () {
     this.type = this.Types.REJ;
 };
 
-Message.prototype.Types = {MSG: "msg", ACK: "ack", REJ: "rej"};
+Message.prototype.Types = {MSG: 'msg', ACK: 'ack', REJ: 'rej'};
 
 module.exports = Message;

--- a/lib/MessageModels/ObjectPosition.js
+++ b/lib/MessageModels/ObjectPosition.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Position = require("./Position.js");
+const Position = require('./Position.js');
 
 function ObjectPosition(objectName, status, latitude, longitude) {
     this.name = objectName;
@@ -12,8 +12,8 @@ ObjectPosition.prototype = Object.create(Position.prototype);
 ObjectPosition.prototype.constructor = ObjectPosition;
 
 ObjectPosition.Status = {
-    "LIVE": "live",
-    "KILLED": "killed"
+    'LIVE': 'live',
+    'KILLED': 'killed'
 };
 
 module.exports = ObjectPosition;

--- a/lib/MessageModels/Position.js
+++ b/lib/MessageModels/Position.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var SymbolIconUtils = require("../SymbolIconUtils");
+const SymbolIconUtils = require('../SymbolIconUtils');
 
 function Position(latitude, longitude) {
     this.latitude = latitude;
@@ -21,7 +21,7 @@ Position.prototype.setTimestamp = function (timestamp) {
 
 Position.prototype.setSymbol = function (symbol) {
     this.symbol = symbol;
-    let symbolIcon = SymbolIconUtils.getSymbolMeaning(symbol);
+    const symbolIcon = SymbolIconUtils.getSymbolMeaning(symbol);
     if (symbolIcon) this.symbolIcon = symbolIcon;
 };
 

--- a/lib/MessageModels/StatusReport.js
+++ b/lib/MessageModels/StatusReport.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var SymbolIconUtils = require("../SymbolIconUtils");
+const SymbolIconUtils = require('../SymbolIconUtils');
 
 function StatusReport() {
 }
@@ -15,37 +15,37 @@ StatusReport.prototype.setStatusText = function (statusText) {
 
 StatusReport.prototype.setSymbol = function (symbol) {
     this.symbol = symbol;
-    let symbolIcon = SymbolIconUtils.getSymbolMeaning(symbol);
+    const symbolIcon = SymbolIconUtils.getSymbolMeaning(symbol);
     if (symbolIcon) this.symbolIcon = symbolIcon;
 };
 
 StatusReport.prototype.setERP = function (code) {
-    var asciiCode = code.charCodeAt(0);
-    var zeroCode = "0".charCodeAt(0);
+    const asciiCode = code.charCodeAt(0);
+    const zeroCode = '0'.charCodeAt(0);
 
-    var erpNumber = asciiCode - zeroCode;
+    const erpNumber = asciiCode - zeroCode;
 
     if(erpNumber >= 0 && erpNumber <= 27) {
         this.erp = Math.pow(erpNumber, 2) * 10;
     }
     else {
-        throw new Error("Wrong ERP in status report");
+        throw new Error('Wrong ERP in status report');
     }
 };
 
 StatusReport.prototype.setBeamHeading = function (code) {
-    var firstLetter = code[0];
+    const firstLetter = code[0];
 
-    if(firstLetter >= "0" && firstLetter <= "9") {
+    if(firstLetter >= '0' && firstLetter <= '9') {
         this.beamHeadingDeg = parseInt(firstLetter) * 10;
     }
-    else if(firstLetter >= "A" && firstLetter <= "Z") {
-        var charNumber = firstLetter.charCodeAt(0) - "A".charCodeAt(0);
-        var alphLen = "Z".charCodeAt(0) - "A".charCodeAt(0);
+    else if(firstLetter >= 'A' && firstLetter <= 'Z') {
+        const charNumber = firstLetter.charCodeAt(0) - 'A'.charCodeAt(0);
+        const alphLen = 'Z'.charCodeAt(0) - 'A'.charCodeAt(0);
         this.beamHeadingDeg = (charNumber * (250 / alphLen)) + 100;
     }
     else
-        throw new Error("Wrong beam heading in status report");
+        throw new Error('Wrong beam heading in status report');
 };
 
 StatusReport.prototype.setLocator = function (locator) {

--- a/lib/MessageModels/index.js
+++ b/lib/MessageModels/index.js
@@ -1,12 +1,12 @@
 module.exports = {
-    Message: require("./Message"),
-    Position: require("./Position"),
-    Telemetry: require("./Telemetry"),
-    TelemetryBitSense: require("./TelemetryBitSense"),
-    TelemetryEquations: require("./TelemetryEquations"),
-    TelemetryLabels: require("./TelemetryLabels"),
-    TelemetryNames: require("./TelemetryNames"),
-    MICEPosition: require("./MICEPosition"),
-    ObjectPosition: require("./ObjectPosition"),
-    StatusReport: require("./StatusReport")
+    Message: require('./Message'),
+    Position: require('./Position'),
+    Telemetry: require('./Telemetry'),
+    TelemetryBitSense: require('./TelemetryBitSense'),
+    TelemetryEquations: require('./TelemetryEquations'),
+    TelemetryLabels: require('./TelemetryLabels'),
+    TelemetryNames: require('./TelemetryNames'),
+    MICEPosition: require('./MICEPosition'),
+    ObjectPosition: require('./ObjectPosition'),
+    StatusReport: require('./StatusReport')
 };

--- a/lib/Object/ObjectParser.js
+++ b/lib/Object/ObjectParser.js
@@ -1,8 +1,8 @@
 'use strict';
-var AbstractParser = require("../AbstractParser.js");
-var ObjectPosition = require("../MessageModels/ObjectPosition.js");
+const AbstractParser = require('../AbstractParser.js');
+const ObjectPosition = require('../MessageModels/ObjectPosition.js');
 
-var PositionParserUtil = require("../Position/PositionParserUtils.js");
+const PositionParserUtil = require('../Position/PositionParserUtils.js');
 
 function ObjectParser() {
 
@@ -12,27 +12,26 @@ ObjectParser.constructor = ObjectParser;
 ObjectParser.prototype = Object.create(AbstractParser.prototype);
 
 ObjectParser.prototype.isMatching = function (bodyContent) {
-    var first = bodyContent[0];
-    return first == ";";
+    const first = bodyContent[0];
+    return first == ';';
 };
 
 ObjectParser.prototype.tryParse = function (bodyContent, aprsMessageHeader) {
-    var name = bodyContent.substr(1, 9).trim();
-    var status;
-    var timestamp;
+    const name = bodyContent.substr(1, 9).trim();
+    let status;
 
-    if (bodyContent[10] == "*")
+    if (bodyContent[10] == '*')
         status = ObjectPosition.Status.LIVE;
-    else if (bodyContent[10] == "_")
+    else if (bodyContent[10] == '_')
         status = ObjectPosition.Status.KILLED;
     else
-        throw new Error("Wrong status symbol: " + bodyContent[10]);
+        throw new Error('Wrong status symbol: ' + bodyContent[10]);
 
-    timestamp = PositionParserUtil.parseTimestamp(bodyContent.substr(11, 7));
+    const timestamp = PositionParserUtil.parseTimestamp(bodyContent.substr(11, 7));
 
-    var dataWithoutTimestampString = bodyContent.substr(18);
+    const dataWithoutTimestampString = bodyContent.substr(18);
 
-    var objectPos = new ObjectPosition(name, status, 0.0, 0.0);
+    const objectPos = new ObjectPosition(name, status, 0.0, 0.0);
     Object.assign(objectPos, PositionParserUtil.parsePositionAndCommentString(dataWithoutTimestampString));
 
     objectPos.setTimestamp(timestamp);
@@ -41,7 +40,7 @@ ObjectParser.prototype.tryParse = function (bodyContent, aprsMessageHeader) {
 };
 
 ObjectParser.prototype.getParserName = function () {
-    return "ObjectParser";
+    return 'ObjectParser';
 };
 
 module.exports = ObjectParser;

--- a/lib/Position/CompressedPositionUtil.js
+++ b/lib/Position/CompressedPositionUtil.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var Position = require("./../MessageModels/Position.js");
+const Position = require('./../MessageModels/Position.js');
 
-var valueFromString = function (data) {
-    var ret = 0;
+const valueFromString = function (data) {
+    let ret = 0;
 
-    for (var i = 0; i < 4; i++) {
+    for (let i = 0; i < 4; i++) {
         ret += (data.charCodeAt(i) - 33) * Math.pow(91, 3 - i);
     }
 
@@ -15,25 +15,25 @@ var valueFromString = function (data) {
 module.exports = {
     parseLatitudeCompressed: function (data) {
         if (data.length != 4)
-            throw new Error("Wrong compressed latitude / longitude length");
+            throw new Error('Wrong compressed latitude / longitude length');
 
         return 90 - valueFromString(data) / 380926;
     },
 
     parseLongitudeCompressed: function (data) {
         if (data.length != 4)
-            throw new Error("Wrong compressed latitude / longitude length");
+            throw new Error('Wrong compressed latitude / longitude length');
 
         return -180 + valueFromString(data) / 190463;
     },
 
     getPositionForCompressedString: function (contentWithoutTimestamp) {
-        var symbol = contentWithoutTimestamp[0] + contentWithoutTimestamp[9];
+        const symbol = contentWithoutTimestamp[0] + contentWithoutTimestamp[9];
 
-        var latitudeString = contentWithoutTimestamp.substr(1, 4);
-        var longitudeString = contentWithoutTimestamp.substr(5, 4);
+        const latitudeString = contentWithoutTimestamp.substr(1, 4);
+        const longitudeString = contentWithoutTimestamp.substr(5, 4);
 
-        var position = new Position(this.parseLatitudeCompressed(latitudeString), this.parseLongitudeCompressed(longitudeString));
+        const position = new Position(this.parseLatitudeCompressed(latitudeString), this.parseLongitudeCompressed(longitudeString));
         position.setSymbol(symbol);
 
         return position;

--- a/lib/Position/MICEParser.js
+++ b/lib/Position/MICEParser.js
@@ -1,8 +1,8 @@
 'use strict';
-var AbstractParser = require("../AbstractParser.js");
-var MICEPosition = require("./../MessageModels/MICEPosition");
+const AbstractParser = require('../AbstractParser.js');
+const MICEPosition = require('./../MessageModels/MICEPosition');
 
-var Utils = require("./MICEParserUtils.js");
+const Utils = require('./MICEParserUtils.js');
 
 function MICEParser() {
 
@@ -13,27 +13,27 @@ MICEParser.constructor = MICEParser;
 MICEParser.prototype = Object.create(AbstractParser.prototype);
 
 MICEParser.prototype.isMatching = function (bodyContent) {
-    var first = bodyContent[0];
-    return (first == "`" || first == "'");
+    const first = bodyContent[0];
+    return (first == '`' || first == '\'');
 };
 
 MICEParser.prototype.tryParse = function (bodyContent, aprsMessageHeader) {
     if (bodyContent.length < 9)
-        throw new Error("Too short body for MIC-E (length < 9)");
+        throw new Error('Too short body for MIC-E (length < 9)');
 
-    var fromDestinationAddress = Utils.readDataFromDestinationAddress(aprsMessageHeader.to.call);
+    const fromDestinationAddress = Utils.readDataFromDestinationAddress(aprsMessageHeader.to.call);
 
-    var longitude = Utils.parseLogitudeFormat(bodyContent.substr(1, 3), fromDestinationAddress.logitudeOffset, fromDestinationAddress.isWest);
+    const longitude = Utils.parseLogitudeFormat(bodyContent.substr(1, 3), fromDestinationAddress.logitudeOffset, fromDestinationAddress.isWest);
 
     //order in MIC-E is symbol code then symbol table
-    var symbol = bodyContent[8] + bodyContent[7];
-    var comment = bodyContent.substr(9);
+    const symbol = bodyContent[8] + bodyContent[7];
+    let comment = bodyContent.substr(9);
 
-    var position = new MICEPosition(fromDestinationAddress.latitude, longitude);
+    const position = new MICEPosition(fromDestinationAddress.latitude, longitude);
     position.setMICEState(fromDestinationAddress.miceState);
     position.setSymbol(symbol);
     position.setExtension(Utils.parseCourseAndSpeed(bodyContent.substr(4, 3)));
-    
+
     if (comment) {
         comment = position.setRadio(comment);
         position.setComment(comment);
@@ -45,7 +45,7 @@ MICEParser.prototype.tryParse = function (bodyContent, aprsMessageHeader) {
 };
 
 MICEParser.prototype.getParserName = function () {
-    return "MICEParser";
+    return 'MICEParser';
 };
 
 module.exports = MICEParser;

--- a/lib/Position/MICEParserUtils.js
+++ b/lib/Position/MICEParserUtils.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var MICEPosition = require("../MessageModels").MICEPosition;
-var CourseSpeed = require("../PostionExtensions/ExtensionModels").CourseSpeed;
-var UncompressedPositionParserUtils = require("./UncompressedPositionParserUtil");
+const MICEPosition = require('../MessageModels').MICEPosition;
+const CourseSpeed = require('../PostionExtensions/ExtensionModels').CourseSpeed;
+const UncompressedPositionParserUtils = require('./UncompressedPositionParserUtil');
 
-var arraysIdentical = function (a, b) {
+const arraysIdentical = function (a, b) {
     if (a.length != b.length)
         return false;
 
-    for (var i = 0; i < a.length; i++) {
+    for (let i = 0; i < a.length; i++) {
         if (a[i] != b[i])
             return false;
     }
@@ -19,38 +19,38 @@ var arraysIdentical = function (a, b) {
 module.exports = {
     getInfoForDestinationAddressChar: function (c) {
         //0 - 0, 1 - 1 custom, 2 - 1 std
-        var asciiCode = c.charCodeAt(0);
-        var ret = {latDigit: 0, message: 0, isNorth: false, longOffset: 0, isWest: false};
+        const asciiCode = c.charCodeAt(0);
+        const ret = {latDigit: 0, message: 0, isNorth: false, longOffset: 0, isWest: false};
 
-        if (c >= "0" && c <= "9") {
-            ret.latDigit = asciiCode - "0".charCodeAt(0);
+        if (c >= '0' && c <= '9') {
+            ret.latDigit = asciiCode - '0'.charCodeAt(0);
         }
-        else if (c >= "A" && c <= "J") {
-            ret.latDigit = asciiCode - "A".charCodeAt(0);
+        else if (c >= 'A' && c <= 'J') {
+            ret.latDigit = asciiCode - 'A'.charCodeAt(0);
             ret.message = 1;
             ret.isNorth = null;
             ret.longOffset = null;
             ret.isWest = null;
         }
-        else if (c == "K") {
+        else if (c == 'K') {
             ret.latDigit = 0;
             ret.message = 1;
             ret.isNorth = null;
             ret.longOffset = null;
             ret.isWest = null;
         }
-        else if (c == "L") {
+        else if (c == 'L') {
             ret.latDigit = 0;
             ret.message = 0;
         }
-        else if (c >= "P" && c <= "Y") {
-            ret.latDigit = asciiCode - "P".charCodeAt(0);
+        else if (c >= 'P' && c <= 'Y') {
+            ret.latDigit = asciiCode - 'P'.charCodeAt(0);
             ret.message = 2;
             ret.isNorth = true;
             ret.longOffset = 100;
             ret.isWest = true;
         }
-        else if (c == "Z") {
+        else if (c == 'Z') {
             ret.latDigit = 0;
             ret.message = 2;
             ret.isNorth = true;
@@ -66,13 +66,13 @@ module.exports = {
          Message: array, 3 elements, values: 0 - 0, 1 - 1 custom, 2 - 1 std
          */
         if (message.length != 3)
-            throw new Error("Message array should contain 3 elements");
+            throw new Error('Message array should contain 3 elements');
 
         if (message[0] == 0 && message[1] == 0 && message[2] == 0)
             return MICEPosition.State.EMERGENCY;
 
-        var isStd = message[0] == 2 || message[1] == 2 || message[2] == 2;
-        var isCustom = message[0] == 1 || message[1] == 1 || message[2] == 1;
+        const isStd = message[0] == 2 || message[1] == 2 || message[2] == 2;
+        const isCustom = message[0] == 1 || message[1] == 1 || message[2] == 1;
 
         if (isStd && isCustom)
             return MICEPosition.State.UNKNOWN;
@@ -101,16 +101,16 @@ module.exports = {
 
     readDataFromDestinationAddress: function (destinationAddressString) {
         if (destinationAddressString.length != 6)
-            throw new Error("Wrong lenght of destination address");
+            throw new Error('Wrong lenght of destination address');
 
-        var latitudeDigits = [];
-        var message = [];
-        var isNorth = false;
-        var longOffset = 0;
-        var isWest = false;
+        const latitudeDigits = [];
+        const message = [];
+        let isNorth = false;
+        let longOffset = 0;
+        let isWest = false;
 
-        for (var i = 1; i <= 6; i++) {
-            var values = this.getInfoForDestinationAddressChar(destinationAddressString[i - 1]);
+        for (let i = 1; i <= 6; i++) {
+            const values = this.getInfoForDestinationAddressChar(destinationAddressString[i - 1]);
 
             latitudeDigits.push(values.latDigit);
 
@@ -128,9 +128,9 @@ module.exports = {
                 isWest = values.isWest;
         }
 
-        var degrees = 10 * latitudeDigits[0] + latitudeDigits[1];
-        var minutes = 10 * latitudeDigits[2] + latitudeDigits[3] + ((10 * latitudeDigits[4] + latitudeDigits[5]) / 100);
-        var latitude = (isNorth ? 1 : -1) * degrees + (minutes / 60);
+        const degrees = 10 * latitudeDigits[0] + latitudeDigits[1];
+        const minutes = 10 * latitudeDigits[2] + latitudeDigits[3] + ((10 * latitudeDigits[4] + latitudeDigits[5]) / 100);
+        const latitude = (isNorth ? 1 : -1) * degrees + (minutes / 60);
 
 
         return {
@@ -143,32 +143,32 @@ module.exports = {
 
     parseLogitudeFormat: function (logitudeString, longitudeOffset, isWest) {
         //degrees
-        var d = longitudeOffset + (logitudeString[0].charCodeAt(0) - 28);
+        let d = longitudeOffset + (logitudeString[0].charCodeAt(0) - 28);
         if (d >= 180 && d <= 189)
             d = d - 80;
         else if (d >= 190 && d <= 199)
             d = d - 190;
 
         //minutes
-        var m = logitudeString[1].charCodeAt(0) - 28;
+        let m = logitudeString[1].charCodeAt(0) - 28;
         if (m >= 60)
             m = m - 60;
 
         //hundredths of minutes
-        var h = logitudeString[2].charCodeAt(0) - 28;
+        const h = logitudeString[2].charCodeAt(0) - 28;
 
-        var minutes = m + (h / 100);
+        const minutes = m + (h / 100);
 
         return (isWest ? -1 : 1) * (d + (minutes / 60));
     },
-    
-    parseCourseAndSpeed: function (data) {
-        var sp = data.charCodeAt(0) - 28;
-        var dc = data.charCodeAt(1) - 28;
-        var se = data.charCodeAt(2) - 28;
 
-        var speedKnots = sp * 10 + Math.floor(dc / 10);
-        var courseDeg = ((dc % 10) * 100) + se;
+    parseCourseAndSpeed: function (data) {
+        const sp = data.charCodeAt(0) - 28;
+        const dc = data.charCodeAt(1) - 28;
+        const se = data.charCodeAt(2) - 28;
+
+        let speedKnots = sp * 10 + Math.floor(dc / 10);
+        let courseDeg = ((dc % 10) * 100) + se;
 
         if(speedKnots >= 800)
             speedKnots -= 800;

--- a/lib/Position/PositionParser.js
+++ b/lib/Position/PositionParser.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var AbstractParser = require("../AbstractParser.js");
-var PositionParserUtils = require("./PositionParserUtils.js");
+const AbstractParser = require('../AbstractParser.js');
+const PositionParserUtils = require('./PositionParserUtils.js');
 
 
 function PositionParser() {
@@ -12,17 +12,17 @@ PositionParser.constructor = PositionParser;
 PositionParser.prototype = Object.create(AbstractParser.prototype);
 
 PositionParser.prototype.isMatching = function (bodyContent) {
-    var first = bodyContent[0];
-    return first == "!" || first == "=" || first == "/" || first == "@";
+    const first = bodyContent[0];
+    return first == '!' || first == '=' || first == '/' || first == '@';
 };
 
 PositionParser.prototype.tryParse = function (bodyContent, aprsMessageHeader) {
-    var messagingEnabled = bodyContent[0] == "=" || bodyContent[0] == "@";
-    var timestamp;
-    var contentWithoutTimestamp = bodyContent;
+    const messagingEnabled = bodyContent[0] == '=' || bodyContent[0] == '@';
+    let timestamp;
+    let contentWithoutTimestamp = bodyContent;
 
     //remove distinguisher char and/or timestamp
-    if (bodyContent[0] == "@" || bodyContent[0] == "/") {
+    if (bodyContent[0] == '@' || bodyContent[0] == '/') {
         //with timestamp
         timestamp = PositionParserUtils.parseTimestamp(bodyContent.substr(1, 7));
         contentWithoutTimestamp = bodyContent.substr(8);
@@ -30,7 +30,7 @@ PositionParser.prototype.tryParse = function (bodyContent, aprsMessageHeader) {
         contentWithoutTimestamp = bodyContent.substr(1);
     }
 
-    var positionObject = PositionParserUtils.parsePositionAndCommentString(contentWithoutTimestamp);
+    const positionObject = PositionParserUtils.parsePositionAndCommentString(contentWithoutTimestamp);
 
     if (timestamp) {
         positionObject.setTimestamp(timestamp);
@@ -42,7 +42,7 @@ PositionParser.prototype.tryParse = function (bodyContent, aprsMessageHeader) {
 };
 
 PositionParser.prototype.getParserName = function () {
-    return "PositionParser";
+    return 'PositionParser';
 };
 
 module.exports = PositionParser;

--- a/lib/Position/PositionParserUtils.js
+++ b/lib/Position/PositionParserUtils.js
@@ -1,28 +1,28 @@
 'use strict';
 
-var UncompressedPositionParserUtil = require("./UncompressedPositionParserUtil.js");
-var CompressedPositionUtil = require("./CompressedPositionUtil.js");
-var Position = require("./../MessageModels/Position.js");
+const UncompressedPositionParserUtil = require('./UncompressedPositionParserUtil.js');
+const CompressedPositionUtil = require('./CompressedPositionUtil.js');
+const Position = require('./../MessageModels/Position.js');
 
-var tryParseNotCompressed = function (contentWithoutTimestamp) {
-    var symbol = contentWithoutTimestamp[8] + contentWithoutTimestamp[18];
-    var latitudeString = contentWithoutTimestamp.substr(0, 8);
-    var longitudeString = contentWithoutTimestamp.substr(9, 9);
+const tryParseNotCompressed = function (contentWithoutTimestamp) {
+    const symbol = contentWithoutTimestamp[8] + contentWithoutTimestamp[18];
+    const latitudeString = contentWithoutTimestamp.substr(0, 8);
+    const longitudeString = contentWithoutTimestamp.substr(9, 9);
 
-    var position = new Position(UncompressedPositionParserUtil.fromDMtoDecimalLatitude(latitudeString), UncompressedPositionParserUtil.fromDMtoDecimalLongitude(longitudeString));
+    const position = new Position(UncompressedPositionParserUtil.fromDMtoDecimalLatitude(latitudeString), UncompressedPositionParserUtil.fromDMtoDecimalLongitude(longitudeString));
 
     position.setSymbol(symbol);
     return position;
 };
 
-var tryParseCompressed = function (contentWithoutTimestamp) {
+const tryParseCompressed = function (contentWithoutTimestamp) {
     return CompressedPositionUtil.getPositionForCompressedString(contentWithoutTimestamp);
 };
 
 module.exports = {
     parsePositionAndCommentString: function (stringPartWithPosAndComment) {
-        var position;
-        var comment;
+        let position;
+        let comment;
 
         if (isNaN(parseInt(stringPartWithPosAndComment[0]))) {
             //probably compressed format
@@ -36,7 +36,7 @@ module.exports = {
         }
 
         if (comment && comment.length > 0) {
-            var parsedFromComment = UncompressedPositionParserUtil.parseAltitudeAndExtension(comment);
+            const parsedFromComment = UncompressedPositionParserUtil.parseAltitudeAndExtension(comment);
 
             if (parsedFromComment.extension)
                 position.setExtension(parsedFromComment.extension);
@@ -52,12 +52,12 @@ module.exports = {
     },
 
     parseTimestamp: function (timestampString) {
-        var now = new Date();
+        const now = new Date();
 
-        var ints = [parseInt(timestampString.substr(0, 2)), parseInt(timestampString.substr(2, 2)), parseInt(timestampString.substr(4, 2))];
+        const ints = [parseInt(timestampString.substr(0, 2)), parseInt(timestampString.substr(2, 2)), parseInt(timestampString.substr(4, 2))];
 
         if (isNaN(ints[0]) || isNaN(ints[1]) || isNaN(ints[2])) {
-            throw new Error("NaN in timestamp:" + ints);
+            throw new Error('NaN in timestamp:' + ints);
         }
 
         if (timestampString[6] == 'z') {
@@ -68,10 +68,10 @@ module.exports = {
             now.setUTCHours(ints[0], ints[1], ints[2], 0);
         }
         else if (timestampString[6] == '/') {
-            throw new Error("Zulu time should be used, not local");
+            throw new Error('Zulu time should be used, not local');
         }
         else
-            throw new Error("Not a timestamp?");
+            throw new Error('Not a timestamp?');
 
         return now;
     }

--- a/lib/Position/UncompressedPositionParserUtil.js
+++ b/lib/Position/UncompressedPositionParserUtil.js
@@ -3,18 +3,18 @@
 module.exports = {
     fromDMtoDecimalLatitude: function (latitude) {
         //position ambiguity, replace spaces
-        latitude = latitude.replace(" ", "0");
+        latitude = latitude.replace(' ', '0');
 
         if (latitude.length != 8 || latitude[4] != '.' || !(latitude[7] == 'N' || latitude[7] == 'S')) {
-            throw new Error("Wrong latitude format: " + latitude);
+            throw new Error('Wrong latitude format: ' + latitude);
         }
 
-        var degrees = parseInt(latitude.substr(0, 2));
-        var minutes = parseInt(latitude.substr(2, 2)) + parseInt(latitude.substr(5, 2)) / 100;
-        var north = latitude[7] == 'N' ? 1 : -1;
+        const degrees = parseInt(latitude.substr(0, 2));
+        const minutes = parseInt(latitude.substr(2, 2)) + parseInt(latitude.substr(5, 2)) / 100;
+        const north = latitude[7] == 'N' ? 1 : -1;
 
         if (isNaN(degrees) || isNaN(minutes)) {
-            throw "Not numbers in position";
+            throw 'Not numbers in position';
         }
 
         return (degrees + minutes / 60) * north;
@@ -22,18 +22,18 @@ module.exports = {
 
     fromDMtoDecimalLongitude: function (longitude) {
         //position ambiguity, replace spaces
-        longitude = longitude.replace(" ", "0");
+        longitude = longitude.replace(' ', '0');
 
         if (longitude.length != 9 || longitude[5] != '.' || !(longitude[8] == 'E' || longitude[8] == 'W')) {
-            throw new Error("Wrong longitude format: " + longitude);
+            throw new Error('Wrong longitude format: ' + longitude);
         }
 
-        var degrees = parseInt(longitude.substr(0, 3));
-        var minutes = parseInt(longitude.substr(3, 2)) + parseInt(longitude.substr(6, 2)) / 100;
-        var east = longitude[8] == 'E' ? 1 : -1;
+        const degrees = parseInt(longitude.substr(0, 3));
+        const minutes = parseInt(longitude.substr(3, 2)) + parseInt(longitude.substr(6, 2)) / 100;
+        const east = longitude[8] == 'E' ? 1 : -1;
 
         if (isNaN(degrees) || isNaN(minutes)) {
-            throw new Error("Not numbers in position");
+            throw new Error('Not numbers in position');
         }
 
         return (degrees + minutes / 60) * east;
@@ -52,25 +52,25 @@ module.exports = {
     },
 
     extractAltitudeMeters: function (msgWithExtension) {
-        var altitudeMark = "/A=";
+        const altitudeMark = '/A=';
 
-        var altPos = msgWithExtension.indexOf(altitudeMark);
+        const altPos = msgWithExtension.indexOf(altitudeMark);
         if (altPos >= 0) {
-            var altitudeString = msgWithExtension.substr(altPos + altitudeMark.length, 6);
-            var altitudeFeets = parseInt(altitudeString);
-            if (isNaN(altitudeFeets) || !altitudeString.match("^[0-9]{6,6}$")) {
-                throw new Error("Error when parsing altitude");
+            const altitudeString = msgWithExtension.substr(altPos + altitudeMark.length, 6);
+            const altitudeFeets = parseInt(altitudeString);
+            if (isNaN(altitudeFeets) || !altitudeString.match('^[0-9]{6,6}$')) {
+                throw new Error('Error when parsing altitude');
             }
 
-            msgWithExtension = msgWithExtension.replace(altitudeMark + altitudeString, "").trim();
+            msgWithExtension = msgWithExtension.replace(altitudeMark + altitudeString, '').trim();
 
             return {msg: msgWithExtension, altitude: this.feetsToMeters(altitudeFeets)};
         }
     },
 
     tryParseExtension: function (potentialExtensionData) {
-        var ExtensionParser = new require("../PostionExtensions/ExtensionParser");
-        var extensionParser = new ExtensionParser();
+        const ExtensionParser = new require('../PostionExtensions/ExtensionParser');
+        const extensionParser = new ExtensionParser();
 
         //if not found return nothing
         if(extensionParser.isMatching(potentialExtensionData)) {
@@ -79,18 +79,18 @@ module.exports = {
     },
 
     parseAltitudeAndExtension: function (comment) {
-        var msgWithoutExtension = comment;
-        var extension;
-        var altitude;
+        let msgWithoutExtension = comment;
+        let extension;
+        let altitude;
 
-        var extensionData = this.tryParseExtension(comment.substr(0, 7));
+        const extensionData = this.tryParseExtension(comment.substr(0, 7));
         if (extensionData) {
             extension = extensionData;
             //remove info about extension for further parsing
             msgWithoutExtension = comment.substr(7);
         }
 
-        var altitudeInfo = this.extractAltitudeMeters(msgWithoutExtension);
+        const altitudeInfo = this.extractAltitudeMeters(msgWithoutExtension);
         if (altitudeInfo) {
             msgWithoutExtension = altitudeInfo.msg;
             altitude = altitudeInfo.altitude;
@@ -98,15 +98,15 @@ module.exports = {
 
         comment = msgWithoutExtension;
 
-        var ret = {};
+        const ret = {};
         if (altitude)
-            ret["altitude"] = altitude;
+            ret['altitude'] = altitude;
 
         if (extension)
-            ret["extension"] = extension;
+            ret['extension'] = extension;
 
         if (comment && comment.length > 0)
-            ret["comment"] = comment;
+            ret['comment'] = comment;
 
         return ret;
     }

--- a/lib/PostionExtensions/ExtensionModels/DFS.js
+++ b/lib/PostionExtensions/ExtensionModels/DFS.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var base = require("./PHG_DFS_base.js");
+const base = require('./PHG_DFS_base.js');
 
 function DFS() {
     base.call(this);
@@ -13,9 +13,9 @@ DFS.prototype.constructor = DFS;
 
 DFS.prototype.setStrengthCode = function(strength) {
     if(strength >= 10 || strength < 0)
-        throw new Error("Illegal strength code");
+        throw new Error('Illegal strength code');
 
     this.strengthS = strength;
-}
+};
 
 module.exports = DFS;

--- a/lib/PostionExtensions/ExtensionModels/PHG.js
+++ b/lib/PostionExtensions/ExtensionModels/PHG.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var base = require("./PHG_DFS_base.js");
+const base = require('./PHG_DFS_base.js');
 
 function PHG() {
     base.call(this);
@@ -13,7 +13,7 @@ PHG.prototype.constructor = PHG;
 
 PHG.prototype.setPowerCode = function(code) {
     if(code >= 10 || code < 0)
-        throw new Error("Illegal power code");
+        throw new Error('Illegal power code');
 
     this.powerWatts = Math.pow(code, 2);
 };

--- a/lib/PostionExtensions/ExtensionModels/PHG_DFS_base.js
+++ b/lib/PostionExtensions/ExtensionModels/PHG_DFS_base.js
@@ -1,4 +1,4 @@
-'use strict'
+'use strict';
 
 function PHG_DFS_base() {
 
@@ -9,23 +9,23 @@ function PHG_DFS_base() {
 
 PHG_DFS_base.prototype.setHeightCode = function(code) {
     if(code >= 10 || code < 0)
-        throw new Error("Illegal height code");
+        throw new Error('Illegal height code');
 
     this.heightFeet = 10 * Math.pow(2, code);
-}
+};
 
 PHG_DFS_base.prototype.setGainCode = function(code) {
     if(code >= 10 || code < 0)
-        throw new Error("Illegal gain code");
+        throw new Error('Illegal gain code');
 
     this.gaindB = code;
-}
+};
 
 PHG_DFS_base.prototype.setDirectivityCode = function(code) {
     if(code >= 9 || code < 0)
-        throw new Error("Illegal directivity code");
+        throw new Error('Illegal directivity code');
 
     this.directivityDeg = code * 45;
-}
+};
 
 module.exports = PHG_DFS_base;

--- a/lib/PostionExtensions/ExtensionModels/index.js
+++ b/lib/PostionExtensions/ExtensionModels/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
 module.exports = {
-    CourseSpeed: require("./CourseSpeed"),
-    DFS: require("./DFS"),
-    PHG: require("./PHG"),
-    RNG: require("./RNG")
+    CourseSpeed: require('./CourseSpeed'),
+    DFS: require('./DFS'),
+    PHG: require('./PHG'),
+    RNG: require('./RNG')
 };

--- a/lib/PostionExtensions/ExtensionParser.js
+++ b/lib/PostionExtensions/ExtensionParser.js
@@ -1,31 +1,31 @@
 'use strict';
 
-var AbstractParser = require("../AbstractParser.js");
-var ExtensionsModels = require("./ExtensionModels");
+const AbstractParser = require('../AbstractParser.js');
+const ExtensionsModels = require('./ExtensionModels');
 
-var PositionParserUtils = require("../Position/UncompressedPositionParserUtil");
+const PositionParserUtils = require('../Position/UncompressedPositionParserUtil');
 
 function ExtensionParser() {
 
 }
 
-var isCourseSpeed = function (bodyContent) {
-    return bodyContent.match("^[0-3][0-9]{2,2}");
+const isCourseSpeed = function (bodyContent) {
+    return bodyContent.match('^[0-3][0-9]{2,2}');
 };
 
-var parseCourseSpeed = function (bodyContent) {
-    var course = parseInt(bodyContent.substr(0, 3));
-    var speed = parseInt(bodyContent.substr(4, 3)); //knots
+const parseCourseSpeed = function (bodyContent) {
+    const course = parseInt(bodyContent.substr(0, 3));
+    const speed = parseInt(bodyContent.substr(4, 3)); //knots
 
     return new ExtensionsModels.CourseSpeed(course, PositionParserUtils.knotsToMetersPerSecond(speed));
 };
 
-var isPHG = function (bodyContent) {
-    return bodyContent.match("^PHG[0-9]{3,3}[0-8]");
+const isPHG = function (bodyContent) {
+    return bodyContent.match('^PHG[0-9]{3,3}[0-8]');
 };
 
-var parsePHG = function (bodyContent) {
-    var ret = new ExtensionsModels.PHG();
+const parsePHG = function (bodyContent) {
+    const ret = new ExtensionsModels.PHG();
     ret.setPowerCode(parseInt(bodyContent[3]));
     ret.setHeightCode(parseInt(bodyContent[4]));
     ret.setGainCode(parseInt(bodyContent[5]));
@@ -33,12 +33,12 @@ var parsePHG = function (bodyContent) {
     return ret;
 };
 
-var isDFS = function (bodyContent) {
-    return bodyContent.match("^DFS[0-9]{3,3}[0-8]");
+const isDFS = function (bodyContent) {
+    return bodyContent.match('^DFS[0-9]{3,3}[0-8]');
 };
 
-var parseDFS = function (bodyContent) {
-    var ret = new ExtensionsModels.DFS();
+const parseDFS = function (bodyContent) {
+    const ret = new ExtensionsModels.DFS();
     ret.setStrengthCode(parseInt(bodyContent[3]));
     ret.setHeightCode(parseInt(bodyContent[4]));
     ret.setGainCode(parseInt(bodyContent[5]));
@@ -46,12 +46,12 @@ var parseDFS = function (bodyContent) {
     return ret;
 };
 
-var isRNG = function (bodyContent) {
-    return bodyContent.match("^RNG[0-9]{4}");
+const isRNG = function (bodyContent) {
+    return bodyContent.match('^RNG[0-9]{4}');
 };
 
 
-var parseRNG = function (bodyContent) {
+const parseRNG = function (bodyContent) {
     return new ExtensionsModels.RNG(PositionParserUtils.milesToMeters(parseInt(bodyContent.substr(3))));
 };
 
@@ -78,7 +78,7 @@ ExtensionParser.prototype.tryParse = function (bodyContent, aprsMessageHeader) {
 };
 
 ExtensionParser.prototype.getParserName = function () {
-    return "ExtensionParser";
+    return 'ExtensionParser';
 };
 
 module.exports = ExtensionParser;

--- a/lib/StatusReport/StatusReportParser.js
+++ b/lib/StatusReport/StatusReportParser.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var AbstractParser = require("../AbstractParser.js");
-var Models = require("../MessageModels");
-var PositionParserUtils = require("../Position/PositionParserUtils");
+const AbstractParser = require('../AbstractParser.js');
+const Models = require('../MessageModels');
+const PositionParserUtils = require('../Position/PositionParserUtils');
 
 function StatusReportParser() {
 
@@ -12,23 +12,23 @@ StatusReportParser.constructor = StatusReportParser;
 StatusReportParser.prototype = Object.create(AbstractParser.prototype);
 
 StatusReportParser.prototype.isMatching = function (bodyContent) {
-    return bodyContent[0] == ">";
+    return bodyContent[0] == '>';
 };
 
 StatusReportParser.prototype.tryParse = function (bodyContent, aprsMessageHeader) {
-    var report = new Models.StatusReport();
+    const report = new Models.StatusReport();
 
-    var maidenheadLocator = bodyContent.match("^>([A-Z]{2}[0-9]{2}[A-Z]{0,2})([/|\\\\].) (.+)"); //regex capturing locator, then symbol and status text
+    const maidenheadLocator = bodyContent.match('^>([A-Z]{2}[0-9]{2}[A-Z]{0,2})([/|\\\\].) (.+)'); //regex capturing locator, then symbol and status text
     if(maidenheadLocator) { //status report with locator
-        var locator = maidenheadLocator[1];
-        var symbol = maidenheadLocator[2];
+        const locator = maidenheadLocator[1];
+        const symbol = maidenheadLocator[2];
         bodyContent = maidenheadLocator[3]; //only status
 
         report.setLocator(locator);
         report.setSymbol(symbol);
     } else { //no locator so might contain timestamp
         try {
-            var timestamp = PositionParserUtils.parseTimestamp(bodyContent.substr(1,7));
+            const timestamp = PositionParserUtils.parseTimestamp(bodyContent.substr(1,7));
             if(timestamp) {
                 report.setTimestamp(timestamp);
                 bodyContent = bodyContent.substr(8); //remove > with timestamp
@@ -41,7 +41,7 @@ StatusReportParser.prototype.tryParse = function (bodyContent, aprsMessageHeader
     }
 
     //check if ERP and heading set
-    if(bodyContent.match("\\^(..)$")) {
+    if(bodyContent.match('\\^(..)$')) {
         report.setBeamHeading(bodyContent[bodyContent.length - 2]);
         report.setERP(bodyContent[bodyContent.length - 1]); //last character
 
@@ -54,7 +54,7 @@ StatusReportParser.prototype.tryParse = function (bodyContent, aprsMessageHeader
 };
 
 StatusReportParser.prototype.getParserName = function () {
-    return "StatusReportParser";
+    return 'StatusReportParser';
 };
 
 module.exports = StatusReportParser;

--- a/lib/Telemetry/TelemetryDescriptionParser.js
+++ b/lib/Telemetry/TelemetryDescriptionParser.js
@@ -1,11 +1,11 @@
 'use strict';
-var AbstractParser = require("../AbstractParser.js");
-var MessageParser = require("../Message/MessageParser");
+const AbstractParser = require('../AbstractParser.js');
+const MessageParser = require('../Message/MessageParser');
 
-var TelemetryNames = require("./../MessageModels/TelemetryNames.js");
-var TelemetryLabels = require("./../MessageModels/TelemetryLabels.js");
-var TelemetryEquations = require("./../MessageModels/TelemetryEquations.js");
-var TelemetryBitSense = require("./../MessageModels/TelemetryBitSense.js");
+const TelemetryNames = require('./../MessageModels/TelemetryNames.js');
+const TelemetryLabels = require('./../MessageModels/TelemetryLabels.js');
+const TelemetryEquations = require('./../MessageModels/TelemetryEquations.js');
+const TelemetryBitSense = require('./../MessageModels/TelemetryBitSense.js');
 
 function TelemetryDescriptionParser() {
 }
@@ -14,35 +14,35 @@ TelemetryDescriptionParser.constructor = TelemetryDescriptionParser;
 TelemetryDescriptionParser.prototype = Object.create(AbstractParser.prototype);
 
 TelemetryDescriptionParser.prototype.isMatching = function (bodyContent) {
-    return !!bodyContent.match("^:.{9,9}:PARM.") || !!bodyContent.match("^:.{9,9}:UNIT.") || !!bodyContent.match("^:.{9,9}:EQNS.") || !!bodyContent.match("^:.{9,9}:BITS.");
+    return !!bodyContent.match('^:.{9,9}:PARM.') || !!bodyContent.match('^:.{9,9}:UNIT.') || !!bodyContent.match('^:.{9,9}:EQNS.') || !!bodyContent.match('^:.{9,9}:BITS.');
 };
 
-var parseParm = function (addressee, descriptions) {
+const parseParm = function (addressee, descriptions) {
     if (descriptions.length > 13)
-        throw new Error("Too many description fields");
+        throw new Error('Too many description fields');
 
     return new TelemetryNames(addressee, descriptions);
 };
 
-var parseUnit = function (addressee, descriptions) {
+const parseUnit = function (addressee, descriptions) {
     if (descriptions.length > 13)
-        throw new Error("Too many unit fields");
+        throw new Error('Too many unit fields');
 
     return new TelemetryLabels(addressee, descriptions);
 };
 
-var parseEqns = function (addressee, descriptions) {
-    var coeff = [];
+const parseEqns = function (addressee, descriptions) {
+    const coeff = [];
 
-    var i, j;
-    var temparray;
-    var chunk = 3;
+    let i, j;
+    let temparray;
+    const chunk = 3;
 
     for (i = 0, j = descriptions.length; i < j; i += chunk) {
         temparray = descriptions.slice(i, i + chunk);
 
         if (temparray.length != 3) {
-            throw new Error("Wrong EQNS format (chunks.length != 3)");
+            throw new Error('Wrong EQNS format (chunks.length != 3)');
         }
 
         coeff.push(temparray.map(parseFloat));
@@ -51,22 +51,22 @@ var parseEqns = function (addressee, descriptions) {
     return new TelemetryEquations(addressee, coeff);
 };
 
-var parseBits = function (addressee, descriptions) {
+const parseBits = function (addressee, descriptions) {
     if (descriptions.length != 2) {
-        throw new Error("In BITS more than 2 elements after splitting by ,");
+        throw new Error('In BITS more than 2 elements after splitting by ,');
     }
 
     if (descriptions[0].length != 8) {
-        throw new Error("More than 8 bits in BITS?");
+        throw new Error('More than 8 bits in BITS?');
     }
 
-    var bits = descriptions[0].split("").map(function (input) {
-        if (input == "1")
+    const bits = descriptions[0].split('').map((input) => {
+        if (input == '1')
             return true;
-        else if (input == "0")
+        else if (input == '0')
             return false;
         else
-            throw new Error("Wrong bit value in BITS");
+            throw new Error('Wrong bit value in BITS');
     });
 
     return new TelemetryBitSense(addressee, bits, descriptions[1]);
@@ -74,25 +74,25 @@ var parseBits = function (addressee, descriptions) {
 
 
 TelemetryDescriptionParser.prototype.tryParse = function (bodyContent, aprsMessageHeader) {
-    var messageParser = new MessageParser();
-    var message = messageParser.tryParse(bodyContent);
+    const messageParser = new MessageParser();
+    const message = messageParser.tryParse(bodyContent);
 
-    var addressee = message.addressee.toString();
-    var descriptions = message.text.substr(5).split(",");
+    const addressee = message.addressee.toString();
+    const descriptions = message.text.substr(5).split(',');
 
-    if (message.text[0] == "P") {
+    if (message.text[0] == 'P') {
         //PARM
         return parseParm(addressee, descriptions);
     }
-    else if (message.text[0] == "U") {
+    else if (message.text[0] == 'U') {
         //UNIT
         return parseUnit(addressee, descriptions);
     }
-    else if (message.text[0] == "E") {
+    else if (message.text[0] == 'E') {
         //EQNS
         return parseEqns(addressee, descriptions);
     }
-    else if (message.text[0] == "B") {
+    else if (message.text[0] == 'B') {
         //BITS
         return parseBits(addressee, descriptions);
     }
@@ -100,7 +100,7 @@ TelemetryDescriptionParser.prototype.tryParse = function (bodyContent, aprsMessa
 };
 
 TelemetryDescriptionParser.prototype.getParserName = function () {
-    return "TelemetryDescParser";
+    return 'TelemetryDescParser';
 };
 
 module.exports = TelemetryDescriptionParser;

--- a/lib/Telemetry/TelemetryParser.js
+++ b/lib/Telemetry/TelemetryParser.js
@@ -1,7 +1,7 @@
 'use strict';
-var AbstractParser = require("../AbstractParser.js");
+const AbstractParser = require('../AbstractParser.js');
 
-var Telemetry = require("./../MessageModels/Telemetry.js");
+const Telemetry = require('./../MessageModels/Telemetry.js');
 
 function TelemetryParser() {
 }
@@ -10,43 +10,43 @@ TelemetryParser.constructor = TelemetryParser;
 TelemetryParser.prototype = Object.create(AbstractParser.prototype);
 
 TelemetryParser.prototype.isMatching = function (bodyContent) {
-    return bodyContent[0] == "T";
+    return bodyContent[0] == 'T';
 };
 
 TelemetryParser.prototype.tryParse = function (bodyContent, aprsMessageHeader) {
-    var commaSeparated = bodyContent.split(",");
+    const commaSeparated = bodyContent.split(',');
 
-    if (commaSeparated.length != 7 || !commaSeparated[0].match("T#[0-9]{3,3}")) {
-        throw new Error("Wrong telemetry format");
+    if (commaSeparated.length != 7 || !commaSeparated[0].match('T#[0-9]{3,3}')) {
+        throw new Error('Wrong telemetry format');
     }
 
-    var id = parseInt(commaSeparated[0].substr(2));
+    const id = parseInt(commaSeparated[0].substr(2));
 
-    var analogValues = commaSeparated.slice(1, 6).map(function (value) {
-        var numericValue = parseInt(value);
-        if (!value.match("^[0-9]{3,3}$") || value > 255 || value < 0)
-            throw new Error("Wrong analog value");
+    const analogValues = commaSeparated.slice(1, 6).map((value) => {
+        const numericValue = parseInt(value);
+        if (!value.match('^[0-9]{3,3}$') || value > 255 || value < 0)
+            throw new Error('Wrong analog value');
 
         return numericValue;
     });
 
-    var digitalString = commaSeparated[6];
+    let digitalString = commaSeparated[6];
 
-    var comment;
+    let comment;
     if (digitalString.length > 8) {
         //have comment, remove it
         comment = digitalString.substr(8);
         digitalString = digitalString.substr(0, 8);
     }
 
-    var digitalValues = digitalString.split('').map(function (value) {
+    const digitalValues = digitalString.split('').map((value) => {
         if (value != '0' && value != '1')
-            throw new Error("Wrong digital value");
+            throw new Error('Wrong digital value');
 
         return value == '1';
     });
 
-    var telemetry = new Telemetry(id, analogValues, digitalValues);
+    const telemetry = new Telemetry(id, analogValues, digitalValues);
 
     if (comment) {
         telemetry.setComment(comment.trim());
@@ -56,7 +56,7 @@ TelemetryParser.prototype.tryParse = function (bodyContent, aprsMessageHeader) {
 };
 
 TelemetryParser.prototype.getParserName = function () {
-    return "TelemetryParser";
+    return 'TelemetryParser';
 };
 
 module.exports = TelemetryParser;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,9 @@
 'use strict';
 
 module.exports = {
-    APRSParser: require("./APRSParser"),
-    Models: require("./MessageModels"),
-    APRSMessage: require("./APRSMessage"),
-    Callsign: require("./Callsign"),
-    APRSISConnector: require("./APRSISConnector")
+    APRSParser: require('./APRSParser'),
+    Models: require('./MessageModels'),
+    APRSMessage: require('./APRSMessage'),
+    Callsign: require('./Callsign'),
+    APRSISConnector: require('./APRSISConnector')
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "JavaScript library for parsing APRS packets",
   "main": "lib/index.js",
   "scripts": {
-    "test": "mocha tests --recursive"
+    "test": "mocha tests --recursive",
+    "lint": "./node_modules/.bin/eslint \"./**/*.js\""
   },
   "repository": {
     "type": "git",
@@ -23,6 +24,7 @@
   "homepage": "https://github.com/adriann0/npm-aprs-parser#readme",
   "devDependencies": {
     "chai": "^3.5.0",
+    "eslint": "^7.18.0",
     "mocha": "^8.2.1"
   }
 }

--- a/tests/APRSParserTests.js
+++ b/tests/APRSParserTests.js
@@ -1,94 +1,94 @@
 'use strict';
 
-var chai = require('chai');
-var expect = chai.expect;
+const chai = require('chai');
+const expect = chai.expect;
 
-var Models = require("../lib/MessageModels");
+const Models = require('../lib/MessageModels');
 
-var APRSMessage = require("../lib/APRSMessage.js");
+const APRSMessage = require('../lib/APRSMessage.js');
 
-var Callsign = require("../lib/Callsign.js");
+const Callsign = require('../lib/Callsign.js');
 
-var APRSParser = require("../lib/index.js");
+const APRSParser = require('../lib/index.js');
 
-describe('APRSParser', function () {
-    var parser = new APRSParser.APRSParser();
+describe('APRSParser', () => {
+    const parser = new APRSParser.APRSParser();
 
-    it('Invalid header', function () {
-        var obj = parser.parse("abc");
+    it('Invalid header', () => {
+        const obj = parser.parse('abc');
         expect(obj).to.be.an.instanceOf(APRSMessage);
         expect(obj.raw).to.exist;
         expect(obj.errors).to.exist;
     });
 
-    it('Header parsing', function () {
-        var obj = parser.parse("SQ7PFS-15>APRS,TCPIP:");
+    it('Header parsing', () => {
+        const obj = parser.parse('SQ7PFS-15>APRS,TCPIP:');
         expect(obj).to.be.an.instanceOf(APRSMessage);
 
         expect(obj).to.exist;
-        expect(obj.from).to.eql(new Callsign("SQ7PFS-15"));
-        expect(obj.to).to.eql(new Callsign("APRS"));
-        expect(obj.via).to.eql([new Callsign("TCPIP")]);
+        expect(obj.from).to.eql(new Callsign('SQ7PFS-15'));
+        expect(obj.to).to.eql(new Callsign('APRS'));
+        expect(obj.via).to.eql([new Callsign('TCPIP')]);
     });
 
-    it('Not compressed position recognition', function () {
-        var obj = parser.parse("SQ7PFS>APRS:!5214.93ND02106.32E&");
+    it('Not compressed position recognition', () => {
+        const obj = parser.parse('SQ7PFS>APRS:!5214.93ND02106.32E&');
 
         expect(obj).to.exist;
         expect(obj.data).to.exist;
         expect(obj.data).to.be.an.instanceOf(Models.Position);
     });
 
-    it('Message recognition', function () {
-        var obj = parser.parse("SQ7PFS>APRS::WU2Z     :Testing{003 ");
+    it('Message recognition', () => {
+        const obj = parser.parse('SQ7PFS>APRS::WU2Z     :Testing{003 ');
 
         expect(obj).to.exist;
         expect(obj.data).to.exist;
         expect(obj.data).to.be.an.instanceOf(Models.Message);
     });
 
-    it('Telemetry recognition', function () {
-        var obj = parser.parse("SQ7PFS>APRS:T#005,199,000,255,073,123,01101001");
+    it('Telemetry recognition', () => {
+        const obj = parser.parse('SQ7PFS>APRS:T#005,199,000,255,073,123,01101001');
 
         expect(obj).to.exist;
         expect(obj.data).to.exist;
         expect(obj.data).to.be.an.instanceOf(Models.Telemetry);
     });
 
-    it('Telemetry names recognition', function () {
-        var obj = parser.parse("SQ7PFS>APRS::N0QBF-11 :PARM.Battery,Btemp,ATemp,Pres,Alt,Camra");
+    it('Telemetry names recognition', () => {
+        const obj = parser.parse('SQ7PFS>APRS::N0QBF-11 :PARM.Battery,Btemp,ATemp,Pres,Alt,Camra');
 
         expect(obj).to.exist;
         expect(obj.data).to.exist;
         expect(obj.data).to.be.an.instanceOf(Models.TelemetryNames);
     });
 
-    it('Telemetry labels/units recognition', function () {
-        var obj = parser.parse("SQ7PFS>APRS::N0QBF-11 :UNIT.v/100,deg.F,deg.F,Mbar,Kft,Click,OPEN,on,on,hi");
+    it('Telemetry labels/units recognition', () => {
+        const obj = parser.parse('SQ7PFS>APRS::N0QBF-11 :UNIT.v/100,deg.F,deg.F,Mbar,Kft,Click,OPEN,on,on,hi');
 
         expect(obj).to.exist;
         expect(obj.data).to.exist;
         expect(obj.data).to.be.an.instanceOf(Models.TelemetryLabels);
     });
 
-    it('Telemetry coefficients recognition', function () {
-        var obj = parser.parse("SQ7PFS>APRS::N0QBF-11 :EQNS.0,5.2,0,0,.53,-32,3,4.39,49,-32,3,18,1,2,3");
+    it('Telemetry coefficients recognition', () => {
+        const obj = parser.parse('SQ7PFS>APRS::N0QBF-11 :EQNS.0,5.2,0,0,.53,-32,3,4.39,49,-32,3,18,1,2,3');
 
         expect(obj).to.exist;
         expect(obj.data).to.exist;
         expect(obj.data).to.be.an.instanceOf(Models.TelemetryEquations);
     });
 
-    it('Telemetry bit sense recognition', function () {
-        var obj = parser.parse("SQ7PFS>APRS::N0QBF-11 :BITS.10110000,N0QBF’s Big Balloon");
+    it('Telemetry bit sense recognition', () => {
+        const obj = parser.parse('SQ7PFS>APRS::N0QBF-11 :BITS.10110000,N0QBF’s Big Balloon');
 
         expect(obj).to.exist;
         expect(obj.data).to.exist;
         expect(obj.data).to.be.an.instanceOf(Models.TelemetryBitSense);
     });
 
-    it('MIC-E position', function () {
-        var obj = parser.parse("SQ7PFS>APDR13:`0U;l!#>/");
+    it('MIC-E position', () => {
+        const obj = parser.parse('SQ7PFS>APDR13:`0U;l!#>/');
 
         expect(obj).to.exist;
         expect(obj.data).to.exist;
@@ -96,8 +96,8 @@ describe('APRSParser', function () {
         expect(obj.data).to.be.an.instanceOf(Models.Position);
     });
 
-    it('Object position', function () {
-        var obj = parser.parse("SQ7PFS>APDR13:;LEADER   *092345z4903.50N/07201.75W>");
+    it('Object position', () => {
+        const obj = parser.parse('SQ7PFS>APDR13:;LEADER   *092345z4903.50N/07201.75W>');
 
         expect(obj).to.exist;
         expect(obj.data).to.exist;
@@ -105,16 +105,16 @@ describe('APRSParser', function () {
         expect(obj.data).to.be.an.instanceOf(Models.Position);
     });
 
-    it('Status report', function () {
-        var obj = parser.parse("SQ7PFS>APDR13:>Hello");
+    it('Status report', () => {
+        const obj = parser.parse('SQ7PFS>APDR13:>Hello');
 
         expect(obj).to.exist;
         expect(obj.data).to.exist;
         expect(obj.data).to.be.an.instanceOf(Models.StatusReport);
     });
 
-    it('Unknown format recognition', function () {
-        var obj = parser.parse("SQ7PFS>APRS:Z");
+    it('Unknown format recognition', () => {
+        const obj = parser.parse('SQ7PFS>APRS:Z');
 
         expect(obj).to.exist;
         expect(obj).to.be.an.instanceOf(APRSMessage);

--- a/tests/CallsignParserTests.js
+++ b/tests/CallsignParserTests.js
@@ -1,19 +1,19 @@
 'use strict';
 
-var chai = require('chai');
-var expect = chai.expect;
-var Callsign = require("../lib/Callsign.js");
+const chai = require('chai');
+const expect = chai.expect;
+const Callsign = require('../lib/Callsign.js');
 
-describe('Callsing', function () {
-    it('Constructor should split into call and SSID', function () {
-        var callsign = new Callsign("SQ7PFS-15");
-        expect(callsign.call).to.equal("SQ7PFS");
-        expect(callsign.ssid).to.equal("15");
+describe('Callsing', () => {
+    it('Constructor should split into call and SSID', () => {
+        const callsign = new Callsign('SQ7PFS-15');
+        expect(callsign.call).to.equal('SQ7PFS');
+        expect(callsign.ssid).to.equal('15');
     });
 
-    it('Callsing without SSID', function () {
-        var callsign = new Callsign("SQ7PFS");
-        expect(callsign.call).to.equal("SQ7PFS");
+    it('Callsing without SSID', () => {
+        const callsign = new Callsign('SQ7PFS');
+        expect(callsign.call).to.equal('SQ7PFS');
         expect(callsign.ssid).to.not.exist;
     });
 });

--- a/tests/MICEParserTests.js
+++ b/tests/MICEParserTests.js
@@ -1,82 +1,82 @@
 'use strict';
 
-var chai = require('chai');
-var expect = chai.expect;
+const chai = require('chai');
+const expect = chai.expect;
 
-var Models = require("../lib/MessageModels");
-var MICEParser = require("../lib/Position/MICEParser.js");
-var MICEParserUtils = require("../lib/Position/MICEParserUtils.js");
-var Callsign = require("../lib/Callsign");
-var App = require("../lib");
+const Models = require('../lib/MessageModels');
+const MICEParser = require('../lib/Position/MICEParser.js');
+const MICEParserUtils = require('../lib/Position/MICEParserUtils.js');
+const Callsign = require('../lib/Callsign');
+const App = require('../lib');
 
-var CourseSpeed = require("../lib/PostionExtensions/ExtensionModels").CourseSpeed;
-var UncompressedPositionParserUtil = require("../lib/Position/UncompressedPositionParserUtil");
+const CourseSpeed = require('../lib/PostionExtensions/ExtensionModels').CourseSpeed;
+const UncompressedPositionParserUtil = require('../lib/Position/UncompressedPositionParserUtil');
 
-describe('MIC-E position parser', function () {
-    it('Parsing position longitude', function () {
-        var parser = new MICEParser();
-        var header = new App.APRSMessage(new Callsign("SQ7PFS"), new Callsign("S32U6T"), []);
+describe('MIC-E position parser', () => {
+    it('Parsing position longitude', () => {
+        const parser = new MICEParser();
+        const header = new App.APRSMessage(new Callsign('SQ7PFS'), new Callsign('S32U6T'), []);
 
-        var parsed = parser.tryParse("`(_f \"Oj/", header);
+        const parsed = parser.tryParse('`(_f "Oj/', header);
 
         expect(parsed).to.be.instanceOf(Models.MICEPosition);
         expect(parsed.longitude).to.be.eql(-1 * (12 + 7.74 / 60));
     });
 
-    it('Parsing symbol', function () {
-        var parser = new MICEParser();
-        var header = new App.APRSMessage(new Callsign("SQ7PFS"), new Callsign("S32U6T"), []);
+    it('Parsing symbol', () => {
+        const parser = new MICEParser();
+        const header = new App.APRSMessage(new Callsign('SQ7PFS'), new Callsign('S32U6T'), []);
 
-        var parsed = parser.tryParse("`(_f \"Oj/", header);
+        const parsed = parser.tryParse('`(_f "Oj/', header);
 
         expect(parsed).to.be.instanceOf(Models.MICEPosition);
-        expect(parsed.symbol).to.be.eql("/j");
+        expect(parsed.symbol).to.be.eql('/j');
     });
 
-    it('Too short', function () {
-        var parser = new MICEParser();
-        var header = new App.APRSMessage(new Callsign("SQ7PFS"), new Callsign("S32U6T"), []);
+    it('Too short', () => {
+        const parser = new MICEParser();
+        const header = new App.APRSMessage(new Callsign('SQ7PFS'), new Callsign('S32U6T'), []);
 
-        expect(function () {
-            parser.tryParse("`(_f \"Oj", header)
+        expect(() => {
+            parser.tryParse('`(_f "Oj', header);
         }).to.throw(Error);
     });
 
-    it('MIC-E Altitude', function () {
-        var parser = new MICEParser();
-        var header = new App.APRSMessage(new Callsign("SQ7PFS"), new Callsign("S32U6T"), []);
+    it('MIC-E Altitude', () => {
+        const parser = new MICEParser();
+        const header = new App.APRSMessage(new Callsign('SQ7PFS'), new Callsign('S32U6T'), []);
 
-        var parsed = parser.tryParse("`(_f \"Oj/\"4T}", header);
+        const parsed = parser.tryParse('`(_f "Oj/"4T}', header);
         expect(parsed.altitude).to.be.eql(61);
     });
 
-    it('MIC-E speed / course', function () {
-        var parser = new MICEParser();
-        var header = new App.APRSMessage(new Callsign("SQ7PFS"), new Callsign("S32U6T"), []);
+    it('MIC-E speed / course', () => {
+        const parser = new MICEParser();
+        const header = new App.APRSMessage(new Callsign('SQ7PFS'), new Callsign('S32U6T'), []);
 
-        var parsed = parser.tryParse("`(_fn\"Oj/", header);
+        const parsed = parser.tryParse('`(_fn"Oj/', header);
 
-        var extension = parsed.extension;
+        const extension = parsed.extension;
         expect(extension).to.be.an.instanceOf(CourseSpeed);
         expect(extension.courseDeg).to.be.eql(251);
         expect(extension.speedMPerS).to.be.eql(UncompressedPositionParserUtil.knotsToMetersPerSecond(20));
     });
 
-    it('Radio model', function () {
-        var parser = new MICEParser();
-        var header = new App.APRSMessage(new Callsign("SQ7PFS"), new Callsign("S32U6T"), []);
+    it('Radio model', () => {
+        const parser = new MICEParser();
+        const header = new App.APRSMessage(new Callsign('SQ7PFS'), new Callsign('S32U6T'), []);
 
-        var parsed = parser.tryParse("`(_f \"Oj/>abcdv", header);
-        expect(parsed.radio).to.be.eql("Kenwood TH-D7A Mobile");
-        expect(parsed.comment).to.be.eql("abcd");
+        const parsed = parser.tryParse('`(_f "Oj/>abcdv', header);
+        expect(parsed.radio).to.be.eql('Kenwood TH-D7A Mobile');
+        expect(parsed.comment).to.be.eql('abcd');
     });
 
 });
 
-describe('MIC-E position parser utils', function () {
-    it('Extracting info from destination address', function () {
+describe('MIC-E position parser utils', () => {
+    it('Extracting info from destination address', () => {
         //example from APRS documentation
-        var info = MICEParserUtils.readDataFromDestinationAddress("S32U6T");
+        const info = MICEParserUtils.readDataFromDestinationAddress('S32U6T');
 
         expect(info.latitude).to.be.eql(33 + 25.64 / 60);
         expect(info.miceState).to.be.eql(Models.MICEPosition.State.M3);
@@ -84,25 +84,25 @@ describe('MIC-E position parser utils', function () {
         expect(info.isWest).to.be.eql(true);
     });
 
-    it('Parsing longitude', function () {
+    it('Parsing longitude', () => {
         //example from APRS documentation
-        var info = MICEParserUtils.parseLogitudeFormat("(_f", 100, true);
+        const info = MICEParserUtils.parseLogitudeFormat('(_f', 100, true);
 
         expect(info).to.be.eql(-1 * (112 + 7.74 / 60));
     });
 
-    it('Not printable characters', function () {
+    it('Not printable characters', () => {
         //0x7F - DEL - 99 deg
-        var str = String.fromCharCode(0x7F) + "_f";
+        const str = String.fromCharCode(0x7F) + '_f';
 
-        var info = MICEParserUtils.parseLogitudeFormat(str, 0, false);
+        const info = MICEParserUtils.parseLogitudeFormat(str, 0, false);
 
         expect(info).to.be.eql(99 + 7.74 / 60);
     });
 
-    it('MIC-E state', function () {
+    it('MIC-E state', () => {
         //0, 0, 1 custom
-        var info = MICEParserUtils.getStateFromMessage([0, 0, 1]);
+        const info = MICEParserUtils.getStateFromMessage([0, 0, 1]);
 
         expect(info).to.be.eql(Models.MICEPosition.State.C6);
     });

--- a/tests/MessageParserTests.js
+++ b/tests/MessageParserTests.js
@@ -1,60 +1,60 @@
 'use strict';
 
-var chai = require('chai');
-var expect = chai.expect;
+const chai = require('chai');
+const expect = chai.expect;
 
-var MessageParser = require("../lib/Message/MessageParser");
-var Message = require("../lib/MessageModels/Message.js");
+const MessageParser = require('../lib/Message/MessageParser');
+const Message = require('../lib/MessageModels/Message.js');
 
-describe('Messages', function () {
-    it('Parsing addressee and content', function () {
-        var content = ":WU2Z     :Testing";
-        var parser = new MessageParser();
+describe('Messages', () => {
+    it('Parsing addressee and content', () => {
+        const content = ':WU2Z     :Testing';
+        const parser = new MessageParser();
 
         expect(parser.isMatching(content.substr(0, 1))).to.equal(true);
 
-        var result = parser.tryParse(content);
-        expect(result.text).to.equal("Testing");
-        expect(result.addressee.call).to.equal("WU2Z");
-        expect(result.type).to.equal("msg");
+        const result = parser.tryParse(content);
+        expect(result.text).to.equal('Testing');
+        expect(result.addressee.call).to.equal('WU2Z');
+        expect(result.type).to.equal('msg');
         expect(result.id).to.not.exist;
     });
 
-    it('Parsing addressee, content and id', function () {
-        var content = ":WU2Z     :Testing{003";
-        var parser = new MessageParser();
+    it('Parsing addressee, content and id', () => {
+        const content = ':WU2Z     :Testing{003';
+        const parser = new MessageParser();
 
         expect(parser.isMatching(content.substr(0, 1))).to.equal(true);
 
-        var result = parser.tryParse(content);
-        expect(result.text).to.equal("Testing");
-        expect(result.addressee.call).to.equal("WU2Z");
+        const result = parser.tryParse(content);
+        expect(result.text).to.equal('Testing');
+        expect(result.addressee.call).to.equal('WU2Z');
         expect(result.id).to.equal(3);
-        expect(result.type).to.equal("msg");
+        expect(result.type).to.equal('msg');
     });
 
-    it('Parsing ACK message', function () {
-        var content = ":KB2ICI   :ack003";
-        var parser = new MessageParser();
+    it('Parsing ACK message', () => {
+        const content = ':KB2ICI   :ack003';
+        const parser = new MessageParser();
 
         expect(parser.isMatching(content.substr(0, 1))).to.equal(true);
 
-        var result = parser.tryParse(content);
+        const result = parser.tryParse(content);
         expect(result.id).to.equal(3);
-        expect(result.addressee.call).to.equal("KB2ICI");
-        expect(result.type).to.equal("ack");
+        expect(result.addressee.call).to.equal('KB2ICI');
+        expect(result.type).to.equal('ack');
     });
 
-    it('Parsing REJ message', function () {
-        var content = ":KB2ICI-14:rej003";
-        var parser = new MessageParser();
+    it('Parsing REJ message', () => {
+        const content = ':KB2ICI-14:rej003';
+        const parser = new MessageParser();
 
         expect(parser.isMatching(content.substr(0, 1))).to.equal(true);
 
-        var result = parser.tryParse(content);
+        const result = parser.tryParse(content);
         expect(result.id).to.equal(3);
-        expect(result.addressee.call).to.equal("KB2ICI");
-        expect(result.addressee.ssid).to.equal("14");
-        expect(result.type).to.equal("rej");
+        expect(result.addressee.call).to.equal('KB2ICI');
+        expect(result.addressee.ssid).to.equal('14');
+        expect(result.type).to.equal('rej');
     });
 });

--- a/tests/ObjectParserTests.js
+++ b/tests/ObjectParserTests.js
@@ -1,68 +1,68 @@
 'use strict';
 
-var chai = require('chai');
-var expect = chai.expect;
+const chai = require('chai');
+const expect = chai.expect;
 
-var Models = require("../lib/MessageModels");
-var ObjectParser = require("../lib/Object/ObjectParser");
+const Models = require('../lib/MessageModels');
+const ObjectParser = require('../lib/Object/ObjectParser');
 
-describe('Object position parser', function () {
-    it('Name, symbol and position', function () {
-        var msg = ";LEADER   *092345z4903.50N/07201.75W>";
-        var parser = new ObjectParser();
+describe('Object position parser', () => {
+    it('Name, symbol and position', () => {
+        const msg = ';LEADER   *092345z4903.50N/07201.75W>';
+        const parser = new ObjectParser();
 
-        var parsed = parser.tryParse(msg);
+        const parsed = parser.tryParse(msg);
 
         expect(parsed).to.be.instanceOf(Models.ObjectPosition);
-        expect(parsed.name).to.be.eql("LEADER");
+        expect(parsed.name).to.be.eql('LEADER');
 
-        var now = new Date();
+        const now = new Date();
         now.setUTCDate(9);
         now.setUTCHours(23, 45, 0, 0);
         expect(parsed.timestamp).to.be.eql(now);
 
-        expect(parsed.symbol).to.be.eql("/>");
+        expect(parsed.symbol).to.be.eql('/>');
         expect(parsed.latitude).to.be.eql(49 + 3.50 / 60);
         expect(parsed.longitude).to.be.eql(-1 * (72 + 1.75 / 60));
         expect(parsed.status).to.be.eql(Models.ObjectPosition.Status.LIVE);
         expect(parsed.comment).to.not.exist;
     });
 
-    it('Altitude within comment', function () {
-        var msg = ";LEADER   *092345z4903.50N/07201.75W>/A=001000Hello world";
-        var parser = new ObjectParser();
+    it('Altitude within comment', () => {
+        const msg = ';LEADER   *092345z4903.50N/07201.75W>/A=001000Hello world';
+        const parser = new ObjectParser();
 
-        var parsed = parser.tryParse(msg);
+        const parsed = parser.tryParse(msg);
 
         expect(parsed).to.be.instanceOf(Models.ObjectPosition);
-        expect(parsed.comment).to.be.eql("Hello world");
+        expect(parsed.comment).to.be.eql('Hello world');
         expect(parsed.altitude).to.be.eql(304.8);
     });
 
-    it('Name, symbol and position (compressed)', function () {
-        var msg = ";LEADER   *092345z/5L!!<*e7>7P[Hello";
-        var parser = new ObjectParser();
+    it('Name, symbol and position (compressed)', () => {
+        const msg = ';LEADER   *092345z/5L!!<*e7>7P[Hello';
+        const parser = new ObjectParser();
 
-        var parsed = parser.tryParse(msg);
+        const parsed = parser.tryParse(msg);
 
         expect(parsed).to.be.instanceOf(Models.ObjectPosition);
-        expect(parsed.name).to.be.eql("LEADER");
+        expect(parsed.name).to.be.eql('LEADER');
 
-        var now = new Date();
+        const now = new Date();
         now.setUTCDate(9);
         now.setUTCHours(23, 45, 0, 0);
         expect(parsed.timestamp).to.be.eql(now);
 
-        expect(parsed.symbol).to.be.eql("/>");
+        expect(parsed.symbol).to.be.eql('/>');
 
-        var epsilon = 0.0001;
-        var expectedLatitude = 49.5;
-        var expectedLongitude = -72.75;
+        const epsilon = 0.0001;
+        const expectedLatitude = 49.5;
+        const expectedLongitude = -72.75;
 
         expect(parsed.latitude).to.be.within(expectedLatitude - epsilon, expectedLatitude + epsilon);
         expect(parsed.longitude).to.be.within(expectedLongitude - epsilon, expectedLongitude + epsilon);
 
         expect(parsed.status).to.be.eql(Models.ObjectPosition.Status.LIVE);
-        expect(parsed.comment).to.be.eql("Hello");
+        expect(parsed.comment).to.be.eql('Hello');
     });
 });

--- a/tests/PositionParserTests.js
+++ b/tests/PositionParserTests.js
@@ -1,59 +1,59 @@
 'use strict';
 
-var chai = require('chai');
-var expect = chai.expect;
+const chai = require('chai');
+const expect = chai.expect;
 
-var Models = require("../lib/MessageModels");
-var PositionParser = require("../lib/Position/PositionParser.js");
+const Models = require('../lib/MessageModels');
+const PositionParser = require('../lib/Position/PositionParser.js');
 
-describe('Position parser', function () {
-    it('Minimal frame (not compressed)', function () {
-        var content = "!4903.50N/07201.75W-";
-        var parser = new PositionParser();
+describe('Position parser', () => {
+    it('Minimal frame (not compressed)', () => {
+        const content = '!4903.50N/07201.75W-';
+        const parser = new PositionParser();
 
         expect(parser.isMatching(content.substr(0, 1))).to.equal(true);
 
-        var parsed = parser.tryParse(content);
+        const parsed = parser.tryParse(content);
 
         expect(parsed).to.be.instanceOf(Models.Position);
         expect(parsed.msgEnabled).to.be.eql(false);
 
-        var latitude = 49 + (3.50 / 60);
-        var longitude = -1 * (72 + (1.75 / 60));
+        const latitude = 49 + (3.50 / 60);
+        const longitude = -1 * (72 + (1.75 / 60));
 
         expect(parsed.latitude).to.be.eql(latitude);
         expect(parsed.longitude).to.be.eql(longitude);
-        expect(parsed.symbol).to.be.eql("/-");
+        expect(parsed.symbol).to.be.eql('/-');
     });
 
-    it('Comment with altitude', function () {
-        var content = "!4903.50N/07201.75W-Hello/A=001000";
-        var parser = new PositionParser();
+    it('Comment with altitude', () => {
+        const content = '!4903.50N/07201.75W-Hello/A=001000';
+        const parser = new PositionParser();
 
-        var parsed = parser.tryParse(content);
+        const parsed = parser.tryParse(content);
 
         expect(parsed).to.be.instanceOf(Models.Position);
-        expect(parsed.comment).to.be.eql("Hello");
+        expect(parsed.comment).to.be.eql('Hello');
         expect(parsed.altitude).to.be.eql(304.8);
     });
 
-    it('Compressed latitude / longitude', function () {
-        var content = "!/5L!!<*e7>7P[";
-        var parser = new PositionParser();
+    it('Compressed latitude / longitude', () => {
+        const content = '!/5L!!<*e7>7P[';
+        const parser = new PositionParser();
 
         expect(parser.isMatching(content.substr(0, 1))).to.equal(true);
 
-        var parsed = parser.tryParse(content);
+        const parsed = parser.tryParse(content);
 
         expect(parsed).to.be.instanceOf(Models.Position);
 
-        var epsilon = 0.0001;
-        var expectedLatitude = 49.5;
-        var expectedLongitude = -72.75;
+        const epsilon = 0.0001;
+        const expectedLatitude = 49.5;
+        const expectedLongitude = -72.75;
 
         expect(parsed.latitude).to.be.within(expectedLatitude - epsilon, expectedLatitude + epsilon);
         expect(parsed.longitude).to.be.within(expectedLongitude - epsilon, expectedLongitude + epsilon);
-        expect(parsed.symbol).to.be.eql("/>");
+        expect(parsed.symbol).to.be.eql('/>');
     });
 
 });

--- a/tests/PositionParserUtilsTests.js
+++ b/tests/PositionParserUtilsTests.js
@@ -1,47 +1,47 @@
 'use strict';
 
-var PositionParserUtil = require("../lib/Position/PositionParserUtils.js");
-var UncompressedPositionParserUtil = require("../lib/Position/UncompressedPositionParserUtil.js");
+const PositionParserUtil = require('../lib/Position/PositionParserUtils.js');
+const UncompressedPositionParserUtil = require('../lib/Position/UncompressedPositionParserUtil.js');
 
-var chai = require('chai');
-var expect = chai.expect;
+const chai = require('chai');
+const expect = chai.expect;
 
-describe('PositionParserUtil', function () {
-    it('Zulu time and date (DHM)', function () {
-        var now = new Date();
+describe('PositionParserUtil', () => {
+    it('Zulu time and date (DHM)', () => {
+        const now = new Date();
         now.setUTCDate(9);
         now.setUTCHours(23, 45, 0, 0);
 
-        var parsed = PositionParserUtil.parseTimestamp("092345z");
+        const parsed = PositionParserUtil.parseTimestamp('092345z');
 
         expect(parsed).to.be.eql(now);
     });
 
-    it('Hours/Minutes/Seconds time format (HMS)', function () {
-        var now = new Date();
+    it('Hours/Minutes/Seconds time format (HMS)', () => {
+        const now = new Date();
         now.setUTCHours(23, 45, 17, 0);
 
-        var parsed = PositionParserUtil.parseTimestamp("234517h");
+        const parsed = PositionParserUtil.parseTimestamp('234517h');
 
         expect(parsed).to.be.eql(now);
     });
 
-    it('Local time', function () {
+    it('Local time', () => {
         /*
          Local time should not be used anymore, parsing local time not implemented
          */
 
-        expect(function () {
-            PositionParserUtil.parseTimestamp("234517/");
+        expect(() => {
+            PositionParserUtil.parseTimestamp('234517/');
         }).to.throw(Error);
     });
 
-    it('Extension, altitude, comment split', function () {
-        var parsed = UncompressedPositionParserUtil.parseAltitudeAndExtension("088/036Hello/A=001000");
+    it('Extension, altitude, comment split', () => {
+        const parsed = UncompressedPositionParserUtil.parseAltitudeAndExtension('088/036Hello/A=001000');
 
         expect(parsed.comment).to.exist;
         expect(parsed.extension).to.exist;
         expect(parsed.altitude).to.exist;
-        expect(parsed.comment).to.eql("Hello");
+        expect(parsed.comment).to.eql('Hello');
     });
 });

--- a/tests/PostionExtensionParserTest.js
+++ b/tests/PostionExtensionParserTest.js
@@ -1,18 +1,18 @@
 'use strict';
 
-var chai = require('chai');
-var expect = chai.expect;
+const chai = require('chai');
+const expect = chai.expect;
 
-var Models = require("../lib/PostionExtensions/ExtensionModels");
-var ExtensionParser = require("../lib/PostionExtensions/ExtensionParser.js");
+const Models = require('../lib/PostionExtensions/ExtensionModels');
+const ExtensionParser = require('../lib/PostionExtensions/ExtensionParser.js');
 
-var PositionParserUtils = require("../lib/Position/UncompressedPositionParserUtil");
+const PositionParserUtils = require('../lib/Position/UncompressedPositionParserUtil');
 
-describe('APRSParser', function () {
-    var parser = new ExtensionParser();
+describe('APRSParser', () => {
+    const parser = new ExtensionParser();
 
-    it('PHG', function () {
-        var parsed = parser.tryParse("PHG5132");
+    it('PHG', () => {
+        const parsed = parser.tryParse('PHG5132');
 
         expect(parsed).to.be.an.instanceOf(Models.PHG);
         expect(parsed.powerWatts).to.eql(25);
@@ -21,8 +21,8 @@ describe('APRSParser', function () {
         expect(parsed.directivityDeg).to.eql(90); //0 = omni
     });
 
-    it('DFS', function () {
-        var parsed = parser.tryParse("DFS2360");
+    it('DFS', () => {
+        const parsed = parser.tryParse('DFS2360');
 
         expect(parsed).to.be.an.instanceOf(Models.DFS);
         expect(parsed.strengthS).to.eql(2);
@@ -31,15 +31,15 @@ describe('APRSParser', function () {
         expect(parsed.directivityDeg).to.eql(0); //0 = omni
     });
 
-    it('RNG', function () {
-        var parsed = parser.tryParse("RNG0050");
+    it('RNG', () => {
+        const parsed = parser.tryParse('RNG0050');
 
         expect(parsed).to.be.an.instanceOf(Models.RNG);
         expect(parsed.rangeMeters).to.eql(PositionParserUtils.milesToMeters(50));
     });
 
-    it('Course / Speed', function () {
-        var parsed = parser.tryParse("088/036");
+    it('Course / Speed', () => {
+        const parsed = parser.tryParse('088/036');
 
         expect(parsed).to.be.an.instanceOf(Models.CourseSpeed);
         expect(parsed.courseDeg).to.eql(88);

--- a/tests/StatusReportParserTests.js
+++ b/tests/StatusReportParserTests.js
@@ -1,84 +1,84 @@
 'use strict';
 
-var chai = require('chai');
-var expect = chai.expect;
+const chai = require('chai');
+const expect = chai.expect;
 
-var Models = require("../lib/MessageModels");
-var StatusReportParser = require("../lib/StatusReport/StatusReportParser");
+const Models = require('../lib/MessageModels');
+const StatusReportParser = require('../lib/StatusReport/StatusReportParser');
 
-describe('StatusReportParser', function () {
-    it('Beam heading parsing', function () {
-        var obj = new Models.StatusReport();
+describe('StatusReportParser', () => {
+    it('Beam heading parsing', () => {
+        const obj = new Models.StatusReport();
 
-        obj.setBeamHeading("Z");
+        obj.setBeamHeading('Z');
         expect(obj.beamHeadingDeg).to.be.eql(350);
 
-        obj.setBeamHeading("A");
+        obj.setBeamHeading('A');
         expect(obj.beamHeadingDeg).to.be.eql(100);
 
-        obj.setBeamHeading("0");
+        obj.setBeamHeading('0');
         expect(obj.beamHeadingDeg).to.be.eql(0);
 
-        obj.setBeamHeading("9");
+        obj.setBeamHeading('9');
         expect(obj.beamHeadingDeg).to.be.eql(90);
     });
 
-    it('ERP parsing', function () {
-        var obj = new Models.StatusReport();
+    it('ERP parsing', () => {
+        const obj = new Models.StatusReport();
 
-        obj.setERP("1");
+        obj.setERP('1');
         expect(obj.erp).to.be.eql(10);
 
-        obj.setERP(":");
+        obj.setERP(':');
         expect(obj.erp).to.be.eql(1000);
 
-        obj.setERP("K");
+        obj.setERP('K');
         expect(obj.erp).to.be.eql(7290);
 
-        expect(function () {
-            obj.setERP("L");
+        expect(() => {
+            obj.setERP('L');
         }).to.throw(Error);
     });
 
-    it('With maidenhead grid locator', function () {
-        var parser = new StatusReportParser();
-        var parsed = parser.tryParse(">IO91SX/- My house");
+    it('With maidenhead grid locator', () => {
+        const parser = new StatusReportParser();
+        const parsed = parser.tryParse('>IO91SX/- My house');
 
         expect(parsed).to.be.instanceOf(Models.StatusReport);
-        expect(parsed.statusText).to.be.eql("My house");
-        expect(parsed.symbol).to.be.eql("/-");
-        expect(parsed.locator).to.be.eql("IO91SX");
+        expect(parsed.statusText).to.be.eql('My house');
+        expect(parsed.symbol).to.be.eql('/-');
+        expect(parsed.locator).to.be.eql('IO91SX');
     });
 
-    it('With timestamp', function () {
-        var parser = new StatusReportParser();
-        var parsed = parser.tryParse(">092345zNet Control Center");
+    it('With timestamp', () => {
+        const parser = new StatusReportParser();
+        const parsed = parser.tryParse('>092345zNet Control Center');
 
         expect(parsed).to.be.instanceOf(Models.StatusReport);
-        expect(parsed.statusText).to.be.eql("Net Control Center");
+        expect(parsed.statusText).to.be.eql('Net Control Center');
 
-        var now = new Date();
+        const now = new Date();
         now.setUTCDate(9);
         now.setUTCHours(23, 45, 0, 0);
         expect(parsed.timestamp).to.be.eql(now);
     });
 
-    it('With ERP and beam heading', function () {
-        var parser = new StatusReportParser();
-        var parsed = parser.tryParse(">IO91SX/- Hello^B7");
+    it('With ERP and beam heading', () => {
+        const parser = new StatusReportParser();
+        const parsed = parser.tryParse('>IO91SX/- Hello^B7');
 
         expect(parsed).to.be.instanceOf(Models.StatusReport);
-        expect(parsed.statusText).to.be.eql("Hello");
-        expect(parsed.symbol).to.be.eql("/-");
+        expect(parsed.statusText).to.be.eql('Hello');
+        expect(parsed.symbol).to.be.eql('/-');
         expect(parsed.erp).to.be.eql(490);
         expect(parsed.beamHeadingDeg).to.be.eql(110);
     });
 
-    it('Regular status report', function () {
-        var parser = new StatusReportParser();
-        var parsed = parser.tryParse(">Hello world");
+    it('Regular status report', () => {
+        const parser = new StatusReportParser();
+        const parsed = parser.tryParse('>Hello world');
 
         expect(parsed).to.be.instanceOf(Models.StatusReport);
-        expect(parsed.statusText).to.be.eql("Hello world");
+        expect(parsed.statusText).to.be.eql('Hello world');
     });
 });

--- a/tests/TelemetryDescriptionParserTests.js
+++ b/tests/TelemetryDescriptionParserTests.js
@@ -1,87 +1,87 @@
 'use strict';
 
-var chai = require('chai');
-var expect = chai.expect;
+const chai = require('chai');
+const expect = chai.expect;
 
-var TelemetryDescriptionParser = require("../lib/Telemetry/TelemetryDescriptionParser");
+const TelemetryDescriptionParser = require('../lib/Telemetry/TelemetryDescriptionParser');
 
-var TelemetryNames = require("../lib/MessageModels/TelemetryNames.js");
-var TelemetryLabels = require("../lib/MessageModels/TelemetryLabels.js");
-var TelemetryEquations = require("../lib/MessageModels/TelemetryEquations.js");
-var TelemetryBitSense = require("../lib/MessageModels/TelemetryBitSense.js");
+const TelemetryNames = require('../lib/MessageModels/TelemetryNames.js');
+const TelemetryLabels = require('../lib/MessageModels/TelemetryLabels.js');
+const TelemetryEquations = require('../lib/MessageModels/TelemetryEquations.js');
+const TelemetryBitSense = require('../lib/MessageModels/TelemetryBitSense.js');
 
-describe('Telemetry description', function () {
-    it('Names (not all fields described)', function () {
-        var content = ":N0QBF-11 :PARM.Battery,Btemp,ATemp,Pres,Alt,Camra";
-        var parser = new TelemetryDescriptionParser();
+describe('Telemetry description', () => {
+    it('Names (not all fields described)', () => {
+        const content = ':N0QBF-11 :PARM.Battery,Btemp,ATemp,Pres,Alt,Camra';
+        const parser = new TelemetryDescriptionParser();
 
         expect(parser.isMatching(content)).to.equal(true);
 
-        var parsed = parser.tryParse(content);
+        const parsed = parser.tryParse(content);
 
         expect(parsed).to.be.an.instanceOf(TelemetryNames);
-        expect(parsed.call).to.eql("N0QBF-11");
-        expect(parsed.desc).to.eql(["Battery", "Btemp", "ATemp", "Pres", "Alt", "Camra"]);
+        expect(parsed.call).to.eql('N0QBF-11');
+        expect(parsed.desc).to.eql(['Battery', 'Btemp', 'ATemp', 'Pres', 'Alt', 'Camra']);
     });
 
-    it('Names (too many fields)', function () {
-        var content = ":N0QBF-11 :PARM.Battery,Btemp,ATemp,Pres,Alt,Camra,Chut,Sun,10m,ATV,Test,Test,Test,Test";
-        var parser = new TelemetryDescriptionParser();
+    it('Names (too many fields)', () => {
+        const content = ':N0QBF-11 :PARM.Battery,Btemp,ATemp,Pres,Alt,Camra,Chut,Sun,10m,ATV,Test,Test,Test,Test';
+        const parser = new TelemetryDescriptionParser();
 
         expect(parser.isMatching(content)).to.equal(true);
 
-        expect(function () {
+        expect(() => {
             parser.tryParse(content);
         }).to.throw(Error);
     });
 
-    it('Unit/Labels', function () {
-        var content = ":N0QBF-11 :UNIT.v/100,deg.F,deg.F,Mbar,Kft,Click,OPEN,on,on,hi";
-        var parser = new TelemetryDescriptionParser();
+    it('Unit/Labels', () => {
+        const content = ':N0QBF-11 :UNIT.v/100,deg.F,deg.F,Mbar,Kft,Click,OPEN,on,on,hi';
+        const parser = new TelemetryDescriptionParser();
 
         expect(parser.isMatching(content)).to.equal(true);
 
-        var parsed = parser.tryParse(content);
+        const parsed = parser.tryParse(content);
 
         expect(parsed).to.be.an.instanceOf(TelemetryLabels);
-        expect(parsed.call).to.eql("N0QBF-11");
-        expect(parsed.labels).to.eql(["v/100", "deg.F", "deg.F", "Mbar", "Kft", "Click", "OPEN", "on", "on", "hi"]);
+        expect(parsed.call).to.eql('N0QBF-11');
+        expect(parsed.labels).to.eql(['v/100', 'deg.F', 'deg.F', 'Mbar', 'Kft', 'Click', 'OPEN', 'on', 'on', 'hi']);
     });
 
-    it('Coeff', function () {
-        var content = ":N0QBF-11 :EQNS.0,5.2,0,0,.53,-32,3,4.39,49,-32,3,18,1,2,3";
-        var parser = new TelemetryDescriptionParser();
+    it('Coeff', () => {
+        const content = ':N0QBF-11 :EQNS.0,5.2,0,0,.53,-32,3,4.39,49,-32,3,18,1,2,3';
+        const parser = new TelemetryDescriptionParser();
 
         expect(parser.isMatching(content)).to.equal(true);
 
-        var parsed = parser.tryParse(content);
+        const parsed = parser.tryParse(content);
 
         expect(parsed).to.be.an.instanceOf(TelemetryEquations);
-        expect(parsed.call).to.eql("N0QBF-11");
+        expect(parsed.call).to.eql('N0QBF-11');
         expect(parsed.coeff).to.eql([[0, 5.2, 0], [0, 0.53, -32], [3, 4.39, 49], [-32, 3, 18], [1, 2, 3]]);
     });
 
-    it('Coeff (not valid number of coefficients)', function () {
-        var content = ":N0QBF-11 :EQNS.0,5.2,0,0,.53,-32,3,4.39,49,-32,3,18,1,2,3,5";
-        var parser = new TelemetryDescriptionParser();
+    it('Coeff (not valid number of coefficients)', () => {
+        const content = ':N0QBF-11 :EQNS.0,5.2,0,0,.53,-32,3,4.39,49,-32,3,18,1,2,3,5';
+        const parser = new TelemetryDescriptionParser();
 
         expect(parser.isMatching(content)).to.equal(true);
 
-        expect(function () {
-            parser.tryParse(content)
+        expect(() => {
+            parser.tryParse(content);
         }).to.throw(Error);
     });
 
-    it('Bit sense', function () {
-        var content = ":N0QBF-11 :BITS.10110000,N0QBF’s Big Balloon";
-        var parser = new TelemetryDescriptionParser();
+    it('Bit sense', () => {
+        const content = ':N0QBF-11 :BITS.10110000,N0QBF’s Big Balloon';
+        const parser = new TelemetryDescriptionParser();
         expect(parser.isMatching(content)).to.equal(true);
 
-        var parsed = parser.tryParse(content);
+        const parsed = parser.tryParse(content);
 
         expect(parsed).to.be.an.instanceOf(TelemetryBitSense);
-        expect(parsed.call).to.eql("N0QBF-11");
+        expect(parsed.call).to.eql('N0QBF-11');
         expect(parsed.sense).to.eql([true, false, true, true, false, false, false, false]);
-        expect(parsed.projectName).to.eql("N0QBF’s Big Balloon");
+        expect(parsed.projectName).to.eql('N0QBF’s Big Balloon');
     });
 });

--- a/tests/TelemetryParserTests.js
+++ b/tests/TelemetryParserTests.js
@@ -1,56 +1,56 @@
 'use strict';
 
-var chai = require('chai');
-var expect = chai.expect;
+const chai = require('chai');
+const expect = chai.expect;
 
-var TelemetryParser = require("../lib/Telemetry/TelemetryParser.js");
+const TelemetryParser = require('../lib/Telemetry/TelemetryParser.js');
 
-describe('Telemetry', function () {
-    it('Telemetry without comment', function () {
-        var content = "T#005,199,000,255,073,123,01101001";
-        var parser = new TelemetryParser();
+describe('Telemetry', () => {
+    it('Telemetry without comment', () => {
+        const content = 'T#005,199,000,255,073,123,01101001';
+        const parser = new TelemetryParser();
 
         expect(parser.isMatching(content.substr(0, 1))).to.equal(true);
 
-        var parsed = parser.tryParse(content);
+        const parsed = parser.tryParse(content);
 
         expect(parsed.id).to.equal(5);
         expect(parsed.analog).to.eql([199, 0, 255, 73, 123]);
         expect(parsed.digital).to.eql([false, true, true, false, true, false, false, true]);
     });
 
-    it('Telemetry with comment', function () {
-        var content = "T#005,199,000,255,073,123,01101001Hello";
-        var parser = new TelemetryParser();
+    it('Telemetry with comment', () => {
+        const content = 'T#005,199,000,255,073,123,01101001Hello';
+        const parser = new TelemetryParser();
 
         expect(parser.isMatching(content.substr(0, 1))).to.equal(true);
 
-        var parsed = parser.tryParse(content);
+        const parsed = parser.tryParse(content);
 
         expect(parsed.id).to.equal(5);
         expect(parsed.analog).to.eql([199, 0, 255, 73, 123]);
         expect(parsed.digital).to.eql([false, true, true, false, true, false, false, true]);
-        expect(parsed.comment).to.equal("Hello");
+        expect(parsed.comment).to.equal('Hello');
     });
 
-    it('Illegal analog value', function () {
-        var content = "T#005,256,000,255,073,123,01101001";
-        var parser = new TelemetryParser();
+    it('Illegal analog value', () => {
+        const content = 'T#005,256,000,255,073,123,01101001';
+        const parser = new TelemetryParser();
 
         expect(parser.isMatching(content.substr(0, 1))).to.equal(true);
 
-        expect(function () {
+        expect(() => {
             parser.tryParse(content);
         }).to.throw(Error);
     });
 
-    it('Illegal digital value', function () {
-        var content = "T#005,255,000,255,073,123,01201001";
-        var parser = new TelemetryParser();
+    it('Illegal digital value', () => {
+        const content = 'T#005,255,000,255,073,123,01201001';
+        const parser = new TelemetryParser();
 
         expect(parser.isMatching(content.substr(0, 1))).to.equal(true);
 
-        expect(function () {
+        expect(() => {
             parser.tryParse(content);
         }).to.throw(Error);
     });


### PR DESCRIPTION
The latest ESLINT prefers single quotes over double, _let_/_const_ instead of _var_, and arrow functions when possible.  This commit is just letting ESLINT auto-fix and validating that everything still works fine :). 