### PR TITLE
Update package.json to v1.0.5 for release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aprs-parser",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "description": "JavaScript library for parsing APRS packets",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
I noticed package.json was v1.0.3 - v1.0.4 was a git tag but not in package.json :).  Once this is merged I can tag it 1.0.5 and npm publish.