### PR TITLE
Weather support (without regex)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
             'error',
             'always'
         ],
+        'no-constant-condition':0,
         'no-unused-vars':0,
         'no-empty':0,
         'no-undef': ['error'],

--- a/README.md
+++ b/README.md
@@ -145,4 +145,4 @@ $ npm install aprs-parser --save
 Library is licensed under the GNU Lesser General Public License. 
 
 
-Library by [adriann0](https://github.com/adriann0) with [Kris Linquist](http://www.github.com/klinquist) as an additioinal contributor.
+Library by [adriann0](https://github.com/adriann0) with [Kris Linquist](http://www.github.com/klinquist) as an additional contributor.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,57 @@ Output:
 
 ```
 
+## Code Example - weather station support
+```javascript
+    const aprs = require("aprs-parser");
+    
+    const parser = new aprs.APRSParser();
+
+    console.log(parser.parse("FW7233>APRS,TCPXX*,qAX,CWOP-2:@231821z5150.13N/01913.68E_239/003g010t042r000p011P011b09969h83L000eMB51"));
+```
+
+Output:
+```
+APRSMessage {
+  from: Callsign { call: 'FW7233' },
+  to: Callsign { call: 'APRS' },
+  via: [
+    Callsign { call: 'TCPXX*' },
+    Callsign { call: 'qAX' },
+    Callsign { ssid: '2', call: 'CWOP' }
+  ],
+  raw: 'FW7233>APRS,TCPXX*,qAX,CWOP-2:@231821z5150.13N/01913.68E_239/003g010t042r000p011P011b09969h83L000eMB51',
+  data: Position {
+    latitude: 51.8355,
+    longitude: 19.228,
+    symbol: '/_',
+    symbolIcon: 'WX Station',
+    extension: CourseSpeed { courseDeg: 239, speedMPerS: 1.543333332 },
+    weather: {
+      windGust: 4.4704,
+      temperature: 5.555555555555555,
+      rain1h: 0,
+      rain24h: 2.794,
+      rainSinceMidnight: 2.794,
+      pressure: 996.9,
+      humidity: 83,
+      luminosity: 0
+    },
+    comment: 'eMB51',
+    timestamp: 2021-01-23T18:21:00.000Z,
+    msgEnabled: true
+  }
+```
+
+For WX stations with position CourseSpeed extension is used to represent wind sped and direction. Units used in weather report:
+- rain1h, rain24h, rainSinceMidnight - millimeters
+- windGust - meters per second
+- temperature - Celcius
+- pressure - millibars
+- luminosity - watts per square meter
+- snow - centimeters
+- humidity - %
+
 ## Code Example - APRS Stream
 
 This library also supports connecting to the APRS "firehose".  An amateur radio license is required to connect.

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ $ npm install aprs-parser --save
 * Telemetry
 * Messages
 * Status reports
+* Weather
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ APRSMessage {
   }
 ```
 
-For WX stations with position CourseSpeed extension is used to represent wind sped and direction. Units used in weather report:
+For WX stations with position CourseSpeed extension is used to represent wind speed and direction. Units used in weather report:
 - rain1h, rain24h, rainSinceMidnight - millimeters
 - windGust - meters per second
 - temperature - Celcius

--- a/lib/MessageModels/Position.js
+++ b/lib/MessageModels/Position.js
@@ -19,6 +19,10 @@ Position.prototype.setTimestamp = function (timestamp) {
     this.timestamp = timestamp;
 };
 
+Position.prototype.setWeather = function (weather) {
+    this.weather = weather;
+};
+
 Position.prototype.setSymbol = function (symbol) {
     this.symbol = symbol;
     const symbolIcon = SymbolIconUtils.getSymbolMeaning(symbol);

--- a/lib/Position/PositionParserUtils.js
+++ b/lib/Position/PositionParserUtils.js
@@ -36,13 +36,16 @@ module.exports = {
         }
 
         if (comment && comment.length > 0) {
-            const parsedFromComment = UncompressedPositionParserUtil.parseAltitudeAndExtension(comment);
+            const parsedFromComment = UncompressedPositionParserUtil.parseAltitudeWeatherAndExtension(comment);
 
             if (parsedFromComment.extension)
                 position.setExtension(parsedFromComment.extension);
 
             if (parsedFromComment.altitude)
                 position.setAltitude(parsedFromComment.altitude);
+
+            if (parsedFromComment.weather)
+                position.setWeather(parsedFromComment.weather);
 
             if (parsedFromComment.comment)
                 position.setComment(parsedFromComment.comment);

--- a/lib/Position/UncompressedPositionParserUtil.js
+++ b/lib/Position/UncompressedPositionParserUtil.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const WeatherParserUtils = require('./WeatherParserUtils');
+
 module.exports = {
     fromDMtoDecimalLatitude: function (latitude) {
         //position ambiguity, replace spaces
@@ -78,7 +80,7 @@ module.exports = {
         }
     },
 
-    parseAltitudeAndExtension: function (comment) {
+    parseAltitudeWeatherAndExtension: function (comment) {
         let msgWithoutExtension = comment;
         let extension;
         let altitude;
@@ -98,7 +100,15 @@ module.exports = {
 
         comment = msgWithoutExtension;
 
+
         const ret = {};
+
+        const weatherData = WeatherParserUtils.parseWeatherData(comment);
+        if (weatherData) {
+            comment = weatherData.comment;
+            ret['weather'] = weatherData.weather;
+        }
+
         if (altitude)
             ret['altitude'] = altitude;
 

--- a/lib/Position/WeatherParserUtils.js
+++ b/lib/Position/WeatherParserUtils.js
@@ -1,0 +1,78 @@
+
+
+const wind_multiplier = 0.44704;
+const rain_multiplier = 0.254;
+const weatherRegEx = new RegExp(/([cSgtrpPlLs#]\d{3}|t-\d{2}|h\d{2}|b\d{5}|s\.\d{2}|s\d\.\d)/g);
+
+const weatherMap = {
+    'g': {
+        keyName: 'wind_gust',
+        val: x => { return Number(x) * wind_multiplier; }
+    },
+    'c': {
+        keyName: 'wind_direction',
+        val: x => { return Number(x); }
+    },
+    't': {
+        keyName: 'temperature',
+        val: x => { return (Number(x) - 32) / 1.8; }
+    },
+    'S': {
+        keyName: 'wind_speed',
+        val: x => { return Number(x) * wind_multiplier; }
+    },
+    'r': {
+        keyName: 'rain_1h',
+        val: x => { return Number(x) * rain_multiplier; }
+    },
+    'p': {
+        keyName: 'rain_24h',
+        val: x => { return Number(x) * rain_multiplier; }
+    },
+    'P': {
+        keyName: 'rain_since_midnight',
+        val: x => { return Number(x) * rain_multiplier; }
+    },
+    'h': {
+        keyName: 'humidity',
+        val: x => { return Number(x); }
+    },
+    'b': {
+        keyName: 'pressure',
+        val: x => { return Number(x) / 10; }
+    },
+    'l': {
+        keyName: 'luminosity',
+        val: x => { return Number(x) + 1000; }
+    },
+    'L': {
+        keyName: 'luminosity',
+        val: x => { return Number(x); }
+    },
+    's': {
+        keyName: 'snow',
+        val: x => { return Number(x) * 25.4; }
+    },
+    '#': {
+        keyName: 'rain_raw',
+        val: x => { return Number(x); }
+    }
+};
+
+module.exports = {
+    parseWeatherData: function (comment) {
+        const weatherRegexMatch = comment.match(weatherRegEx);
+        if (!weatherRegexMatch) return;
+        const weather = {};
+        for (let i = 0; i < weatherRegexMatch.length; i++){
+            if (weatherMap[weatherRegexMatch[i].substr(0, 1)]) {
+                weather[weatherMap[weatherRegexMatch[i].substr(0, 1)].keyName] = weatherMap[weatherRegexMatch[i].substr(0, 1)].val(weatherRegexMatch[i].substr(1));
+            }
+        }
+        //remove weather data from the body content
+        comment = comment.substr(0,comment.indexOf(weatherRegexMatch[0])) + comment.substr(comment.indexOf(weatherRegexMatch[weatherRegexMatch.length - 1]) + weatherRegexMatch[weatherRegexMatch.length - 1].length);
+        return {
+            weather, comment
+        };
+    }
+};

--- a/lib/Position/WeatherParserUtils.js
+++ b/lib/Position/WeatherParserUtils.js
@@ -1,59 +1,59 @@
 
 
-const wind_multiplier = 0.44704;
-const rain_multiplier = 0.254;
+const windMultiplier = 0.44704;
+const rainMultiplier = 0.254;
 const weatherRegEx = new RegExp(/([cSgtrpPlLs#]\d{3}|t-\d{2}|h\d{2}|b\d{5}|s\.\d{2}|s\d\.\d)/g);
 
 const weatherMap = {
-    'g': {
+    'g': { //peak wind speed in the past 5 minutes, in mph (converting it to kmph)
         keyName: 'wind_gust',
-        val: x => { return Number(x) * wind_multiplier; }
+        val: x => { return Number(x) * windMultiplier; }
     },
-    'c': {
+    'c': { //wind direction in degrees
         keyName: 'wind_direction',
         val: x => { return Number(x); }
     },
-    't': {
+    't': { //Temperature in fahrenheit, converting it to celsius
         keyName: 'temperature',
         val: x => { return (Number(x) - 32) / 1.8; }
     },
-    'S': {
+    'S': { //sustained one-minute wind speed, in mph (converting it to kmph)
         keyName: 'wind_speed',
-        val: x => { return Number(x) * wind_multiplier; }
+        val: x => { return Number(x) * windMultiplier; }
     },
-    'r': {
+    'r': { //Rainfall in hundredths of an inch, converting it to cm.
         keyName: 'rain_1h',
-        val: x => { return Number(x) * rain_multiplier; }
+        val: x => { return Number(x) * rainMultiplier; }
     },
-    'p': {
+    'p': { //Rainfall in hundredths of an inch, converting it to cm.
         keyName: 'rain_24h',
-        val: x => { return Number(x) * rain_multiplier; }
+        val: x => { return Number(x) * rainMultiplier; }
     },
-    'P': {
+    'P': { //Rainfall in hundredths of an inch, converting it to cm.
         keyName: 'rain_since_midnight',
-        val: x => { return Number(x) * rain_multiplier; }
+        val: x => { return Number(x) * rainMultiplier; }
     },
-    'h': {
+    'h': {  //Relative humidity in %
         keyName: 'humidity',
         val: x => { return Number(x); }
     },
-    'b': {
+    'b': { //barometric pressure (in tenths of millibars, converting it to millibars)
         keyName: 'pressure',
         val: x => { return Number(x) / 10; }
     },
-    'l': {
+    'l': { ////Luminosity (in watts per square meter) 1000 and above
         keyName: 'luminosity',
         val: x => { return Number(x) + 1000; }
     },
-    'L': {
+    'L': {  //Luminosity (in watts per square meter) 999 and below
         keyName: 'luminosity',
         val: x => { return Number(x); }
     },
-    's': {
+    's': {  //Snowfall in the last 24 hours, inches converting to cm
         keyName: 'snow',
         val: x => { return Number(x) * 25.4; }
     },
-    '#': {
+    '#': {  // raw rain counter
         keyName: 'rain_raw',
         val: x => { return Number(x); }
     }

--- a/lib/Position/WeatherParserUtils.js
+++ b/lib/Position/WeatherParserUtils.js
@@ -1,17 +1,11 @@
 'use strict';
 
-const windMultiplier = 0.44704;
 const rainMultiplier = 0.254;
 
 const weatherParsingMap = {
-    'g': { //peak wind speed in the past 5 minutes, in mph (converting it to kmph)
+    'g': { //peak wind speed in the past 5 minutes, in mph (converting it to meters per second)
         valueName: 'windGust',
-        valueConversionFunction: x => { return Number(x) * windMultiplier; },
-        valueLength: 3
-    },
-    'c': { //wind direction in degrees
-        valueName: 'windDirection',
-        valueConversionFunction: x => { return Number(x); },
+        valueConversionFunction: x => { return Number(x) * 0.4470; },
         valueLength: 3
     },
     't': { //Temperature in fahrenheit, converting it to celsius
@@ -19,22 +13,17 @@ const weatherParsingMap = {
         valueConversionFunction: x => { return (Number(x) - 32) / 1.8; },
         valueLength: 3
     },
-    'S': { //sustained one-minute wind speed, in mph (converting it to kmph)
-        valueName: 'windSpeed',
-        valueConversionFunction: x => { return Number(x) * windMultiplier; },
-        valueLength: 3
-    },
-    'r': { //Rainfall in hundredths of an inch, converting it to cm.
+    'r': { //Rainfall in hundredths of an inch, converting it to mm.
         valueName: 'rain1h',
         valueConversionFunction: x => { return Number(x) * rainMultiplier; },
         valueLength: 3
     },
-    'p': { //Rainfall in hundredths of an inch, converting it to cm.
+    'p': { //Rainfall in hundredths of an inch, converting it to mm.
         valueName: 'rain24h',
         valueConversionFunction: x => { return Number(x) * rainMultiplier; },
         valueLength: 3
     },
-    'P': { //Rainfall in hundredths of an inch, converting it to cm.
+    'P': { //Rainfall in hundredths of an inch, converting it to mm.
         valueName: 'rainSinceMidnight',
         valueConversionFunction: x => { return Number(x) * rainMultiplier; },
         valueLength: 3
@@ -61,7 +50,7 @@ const weatherParsingMap = {
     },
     's': {  //Snowfall in the last 24 hours, inches converting to cm
         valueName: 'snow',
-        valueConversionFunction: x => { return Number(x) * 25.4; },
+        valueConversionFunction: x => { return Number(x) * 2.54; },
         valueLength: 3
     },
     '#': {  // raw rain counter

--- a/lib/Position/WeatherParserUtils.js
+++ b/lib/Position/WeatherParserUtils.js
@@ -61,7 +61,7 @@ const weatherParsingMap = {
 };
 
 function isUnknownWeatherValue(rawValue) {
-    return rawValue == " ".repeat(rawValue.length) || rawValue == ".".repeat(rawValue.length);
+    return rawValue == ' '.repeat(rawValue.length) || rawValue == '.'.repeat(rawValue.length);
 }
 
 module.exports = {
@@ -83,6 +83,7 @@ module.exports = {
             const symbolValue = parsedWeatherSymbol.valueConversionFunction(rawSymbolValue);
             if (!isNaN(symbolValue)) {
                 weather[parsedWeatherSymbol.valueName] = symbolValue;
+
             }
             else {
                 // Value is not a number. Some string values describe unknown / irrelevant data - in that cases we should continue parsing (just skip current field).
@@ -92,9 +93,9 @@ module.exports = {
                     break;
                 }
             }
-
             // advance by symbol and value lenght
             commentCurentPosition += 1 + parsedWeatherSymbol.valueLength;
+
         }
 
         if (commentCurentPosition > 0) {

--- a/lib/Position/WeatherParserUtils.js
+++ b/lib/Position/WeatherParserUtils.js
@@ -2,78 +2,120 @@
 
 const windMultiplier = 0.44704;
 const rainMultiplier = 0.254;
-const weatherRegEx = new RegExp(/([cSgtrpPlLs#]\d{3}|t-\d{2}|h\d{2}|b\d{5}|s\.\d{2}|s\d\.\d)/g);
 
-const weatherMap = {
+const weatherParsingMap = {
     'g': { //peak wind speed in the past 5 minutes, in mph (converting it to kmph)
-        keyName: 'wind_gust',
-        val: x => { return Number(x) * windMultiplier; }
+        valueName: 'windGust',
+        valueConversionFunction: x => { return Number(x) * windMultiplier; },
+        valueLength: 3
     },
     'c': { //wind direction in degrees
-        keyName: 'wind_direction',
-        val: x => { return Number(x); }
+        valueName: 'windDirection',
+        valueConversionFunction: x => { return Number(x); },
+        valueLength: 3
     },
     't': { //Temperature in fahrenheit, converting it to celsius
-        keyName: 'temperature',
-        val: x => { return (Number(x) - 32) / 1.8; }
+        valueName: 'temperature',
+        valueConversionFunction: x => { return (Number(x) - 32) / 1.8; },
+        valueLength: 3
     },
     'S': { //sustained one-minute wind speed, in mph (converting it to kmph)
-        keyName: 'wind_speed',
-        val: x => { return Number(x) * windMultiplier; }
+        valueName: 'windSpeed',
+        valueConversionFunction: x => { return Number(x) * windMultiplier; },
+        valueLength: 3
     },
     'r': { //Rainfall in hundredths of an inch, converting it to cm.
-        keyName: 'rain_1h',
-        val: x => { return Number(x) * rainMultiplier; }
+        valueName: 'rain1h',
+        valueConversionFunction: x => { return Number(x) * rainMultiplier; },
+        valueLength: 3
     },
     'p': { //Rainfall in hundredths of an inch, converting it to cm.
-        keyName: 'rain_24h',
-        val: x => { return Number(x) * rainMultiplier; }
+        valueName: 'rain24h',
+        valueConversionFunction: x => { return Number(x) * rainMultiplier; },
+        valueLength: 3
     },
     'P': { //Rainfall in hundredths of an inch, converting it to cm.
-        keyName: 'rain_since_midnight',
-        val: x => { return Number(x) * rainMultiplier; }
+        valueName: 'rainSinceMidnight',
+        valueConversionFunction: x => { return Number(x) * rainMultiplier; },
+        valueLength: 3
     },
     'h': {  //Relative humidity in %
-        keyName: 'humidity',
-        val: x => { return Number(x); }
+        valueName: 'humidity',
+        valueConversionFunction: x => { return Number(x); },
+        valueLength: 2
     },
     'b': { //barometric pressure (in tenths of millibars, converting it to millibars)
-        keyName: 'pressure',
-        val: x => { return Number(x) / 10; }
+        valueName: 'pressure',
+        valueConversionFunction: x => { return Number(x) / 10; },
+        valueLength: 5
     },
     'l': { ////Luminosity (in watts per square meter) 1000 and above
-        keyName: 'luminosity',
-        val: x => { return Number(x) + 1000; }
+        valueName: 'luminosity',
+        valueConversionFunction: x => { return Number(x) + 1000; },
+        valueLength: 3
     },
     'L': {  //Luminosity (in watts per square meter) 999 and below
-        keyName: 'luminosity',
-        val: x => { return Number(x); }
+        valueName: 'luminosity',
+        valueConversionFunction: x => { return Number(x); },
+        valueLength: 3
     },
     's': {  //Snowfall in the last 24 hours, inches converting to cm
-        keyName: 'snow',
-        val: x => { return Number(x) * 25.4; }
+        valueName: 'snow',
+        valueConversionFunction: x => { return Number(x) * 25.4; },
+        valueLength: 3
     },
     '#': {  // raw rain counter
-        keyName: 'rain_raw',
-        val: x => { return Number(x); }
+        valueName: 'rainRaw',
+        valueConversionFunction: x => { return Number(x); },
+        valueLength: 3
     }
 };
 
+function isUnknownWeatherValue(rawValue) {
+    return rawValue == " ".repeat(rawValue.length) || rawValue == ".".repeat(rawValue.length);
+}
+
 module.exports = {
     parseWeatherData: function (comment) {
-        const weatherRegexMatch = comment.match(weatherRegEx);
-        if (!weatherRegexMatch) return;
+        let commentCurentPosition = 0;
         const weather = {};
-        for (let i = 0; i < weatherRegexMatch.length; i++){
-            if (weatherMap[weatherRegexMatch[i][0]]) {
-                const weatherFieldInfo = weatherMap[weatherRegexMatch[i][0]];
-                weather[weatherFieldInfo.keyName] = weatherFieldInfo.val(weatherRegexMatch[i].substr(1));
+
+        while (true) {
+            const parsedWeatherSymbol = weatherParsingMap[comment[commentCurentPosition]];
+
+            if (!parsedWeatherSymbol) {
+                // current letter doesn't look like weather symbol, skip parsing the rest of message
+                break;
             }
+            
+            // extract raw weather value (skip weather symbol)
+            const rawSymbolValue = comment.substr(commentCurentPosition + 1, parsedWeatherSymbol.valueLength);
+
+            const symbolValue = parsedWeatherSymbol.valueConversionFunction(rawSymbolValue);
+            if (!isNaN(symbolValue)) {
+                weather[parsedWeatherSymbol.valueName] = symbolValue;
+            } 
+            else {
+                // Value is not a number. Some string values describe unknown / irrelevant data - in that cases we should continue parsing (just skip current field).
+                // Otherwise value is illegal and we should stop parsing.
+
+                if (!isUnknownWeatherValue(rawSymbolValue)) {
+                    // illegal value
+                    break;
+                }
+            }
+
+            // advance by symbol and value lenght
+            commentCurentPosition += 1 + parsedWeatherSymbol.valueLength;
         }
-        //remove weather data from the body content
-        comment = comment.substr(0,comment.indexOf(weatherRegexMatch[0])) + comment.substr(comment.indexOf(weatherRegexMatch[weatherRegexMatch.length - 1]) + weatherRegexMatch[weatherRegexMatch.length - 1].length);
-        return {
-            weather, comment
-        };
+
+        if (commentCurentPosition > 0) {
+            // remove parsed weather information from comment
+            comment = comment.substr(commentCurentPosition);
+
+            return {
+                weather, comment
+            };
+        }
     }
 };

--- a/lib/Position/WeatherParserUtils.js
+++ b/lib/Position/WeatherParserUtils.js
@@ -94,7 +94,6 @@ module.exports = {
             }
             // advance by symbol and value lenght
             commentCurentPosition += 1 + parsedWeatherSymbol.valueLength;
-
         }
 
         if (commentCurentPosition > 0) {

--- a/lib/Position/WeatherParserUtils.js
+++ b/lib/Position/WeatherParserUtils.js
@@ -1,4 +1,4 @@
-
+'use strict';
 
 const windMultiplier = 0.44704;
 const rainMultiplier = 0.254;

--- a/lib/Position/WeatherParserUtils.js
+++ b/lib/Position/WeatherParserUtils.js
@@ -83,7 +83,6 @@ module.exports = {
             const symbolValue = parsedWeatherSymbol.valueConversionFunction(rawSymbolValue);
             if (!isNaN(symbolValue)) {
                 weather[parsedWeatherSymbol.valueName] = symbolValue;
-
             }
             else {
                 // Value is not a number. Some string values describe unknown / irrelevant data - in that cases we should continue parsing (just skip current field).

--- a/lib/Position/WeatherParserUtils.js
+++ b/lib/Position/WeatherParserUtils.js
@@ -76,7 +76,7 @@ function isUnknownWeatherValue(rawValue) {
 }
 
 module.exports = {
-    parseWeatherData: function (comment) {
+    parseWeatherData: (comment) => {
         let commentCurentPosition = 0;
         const weather = {};
 
@@ -87,18 +87,17 @@ module.exports = {
                 // current letter doesn't look like weather symbol, skip parsing the rest of message
                 break;
             }
-            
+
             // extract raw weather value (skip weather symbol)
             const rawSymbolValue = comment.substr(commentCurentPosition + 1, parsedWeatherSymbol.valueLength);
 
             const symbolValue = parsedWeatherSymbol.valueConversionFunction(rawSymbolValue);
             if (!isNaN(symbolValue)) {
                 weather[parsedWeatherSymbol.valueName] = symbolValue;
-            } 
+            }
             else {
                 // Value is not a number. Some string values describe unknown / irrelevant data - in that cases we should continue parsing (just skip current field).
                 // Otherwise value is illegal and we should stop parsing.
-
                 if (!isUnknownWeatherValue(rawSymbolValue)) {
                     // illegal value
                     break;

--- a/lib/Position/WeatherParserUtils.js
+++ b/lib/Position/WeatherParserUtils.js
@@ -66,7 +66,7 @@ module.exports = {
         const weather = {};
         for (let i = 0; i < weatherRegexMatch.length; i++){
             if (weatherMap[weatherRegexMatch[i][0]]) {
-                const weatherFieldInfo = weatherMap[weatherRegexMatch[i][0]]
+                const weatherFieldInfo = weatherMap[weatherRegexMatch[i][0]];
                 weather[weatherFieldInfo.keyName] = weatherFieldInfo.val(weatherRegexMatch[i].substr(1));
             }
         }

--- a/lib/Position/WeatherParserUtils.js
+++ b/lib/Position/WeatherParserUtils.js
@@ -65,8 +65,9 @@ module.exports = {
         if (!weatherRegexMatch) return;
         const weather = {};
         for (let i = 0; i < weatherRegexMatch.length; i++){
-            if (weatherMap[weatherRegexMatch[i].substr(0, 1)]) {
-                weather[weatherMap[weatherRegexMatch[i].substr(0, 1)].keyName] = weatherMap[weatherRegexMatch[i].substr(0, 1)].val(weatherRegexMatch[i].substr(1));
+            if (weatherMap[weatherRegexMatch[i][0]]) {
+                const weatherFieldInfo = weatherMap[weatherRegexMatch[i][0]]
+                weather[weatherFieldInfo.keyName] = weatherFieldInfo.val(weatherRegexMatch[i].substr(1));
             }
         }
         //remove weather data from the body content

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aprs-parser",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "JavaScript library for parsing APRS packets",
   "main": "lib/index.js",
   "scripts": {

--- a/tests/PositionParserTests.js
+++ b/tests/PositionParserTests.js
@@ -58,6 +58,7 @@ describe('Position parser', () => {
         expect(parsed.extension.courseDeg).to.be.eql(239);
         expect(parsed.extension.speedMPerS).to.be.within(expectedSpeed - epsilon, expectedSpeed + epsilon);
         expect(parsed.weather.pressure).to.be.eql(996.9);
+        expect(parsed.comment).to.be.eql("eMB51");
     })
 
     it('Compressed latitude / longitude', () => {

--- a/tests/PositionParserTests.js
+++ b/tests/PositionParserTests.js
@@ -47,6 +47,19 @@ describe('Position parser', () => {
         expect(parsed.weather.humidity).to.be.eql(47);
     });
 
+    it('Comment with course/speed extension and weather', () => {
+        const content = '@231821z5150.13N/01913.68E_239/003g010t042r000p011P011b09969h83L000eMB51';
+        const parser = new PositionParser();
+        const parsed = parser.tryParse(content);
+
+        const epsilon = 0.0001;
+        const expectedSpeed = 1.543333332;
+
+        expect(parsed.extension.courseDeg).to.be.eql(239);
+        expect(parsed.extension.speedMPerS).to.be.within(expectedSpeed - epsilon, expectedSpeed + epsilon);
+        expect(parsed.weather.pressure).to.be.eql(996.9);
+    })
+
     it('Compressed latitude / longitude', () => {
         const content = '!/5L!!<*e7>7P[';
         const parser = new PositionParser();

--- a/tests/PositionParserTests.js
+++ b/tests/PositionParserTests.js
@@ -58,8 +58,8 @@ describe('Position parser', () => {
         expect(parsed.extension.courseDeg).to.be.eql(239);
         expect(parsed.extension.speedMPerS).to.be.within(expectedSpeed - epsilon, expectedSpeed + epsilon);
         expect(parsed.weather.pressure).to.be.eql(996.9);
-        expect(parsed.comment).to.be.eql("eMB51");
-    })
+        expect(parsed.comment).to.be.eql('eMB51');
+    });
 
     it('Compressed latitude / longitude', () => {
         const content = '!/5L!!<*e7>7P[';

--- a/tests/PositionParserTests.js
+++ b/tests/PositionParserTests.js
@@ -37,6 +37,16 @@ describe('Position parser', () => {
         expect(parsed.altitude).to.be.eql(304.8);
     });
 
+    it('Comment with weather', () => {
+        const content = '!4237.15N/00625.38W_261/002g005t049r000p000P000h47b10224myWeather';
+        const parser = new PositionParser();
+        const parsed = parser.tryParse(content);
+        expect(parsed).to.be.instanceOf(Models.Position);
+        expect(parsed.comment).to.be.eql('myWeather');
+        expect(parsed.weather).to.not.be.null;
+        expect(parsed.weather.humidity).to.be.eql(47);
+    });
+
     it('Compressed latitude / longitude', () => {
         const content = '!/5L!!<*e7>7P[';
         const parser = new PositionParser();

--- a/tests/PositionParserUtilsTests.js
+++ b/tests/PositionParserUtilsTests.js
@@ -37,8 +37,7 @@ describe('PositionParserUtil', () => {
     });
 
     it('Extension, altitude, comment split', () => {
-        const parsed = UncompressedPositionParserUtil.parseAltitudeAndExtension('088/036Hello/A=001000');
-
+        const parsed = UncompressedPositionParserUtil.parseAltitudeWeatherAndExtension('088/036Hello/A=001000');
         expect(parsed.comment).to.exist;
         expect(parsed.extension).to.exist;
         expect(parsed.altitude).to.exist;

--- a/tests/WeatherParserUtilsTests.js
+++ b/tests/WeatherParserUtilsTests.js
@@ -53,13 +53,13 @@ describe('WeatherParserUtils', () => {
         expect(parsed.comment).to.eql('Comment');
     });
 
-    it("Only temperature (irrelevant values replaced by spaces)", () => {
+    it('Only temperature (irrelevant values replaced by spaces)', () => {
         const parsed = WeatherParserUtils.parseWeatherData('c   s   g   t-99Comment');
         expect(parsed.weather.temperature).to.eql((-99-32)/1.8);
         expect(parsed.comment).to.eql('Comment');
     });
 
-    it("Invalid value stops parsing", () => {
+    it('Invalid value stops parsing', () => {
         const parsed = WeatherParserUtils.parseWeatherData('c...s...g...t-99hXXb12345');
         expect(parsed.weather.temperature).to.eql((-99-32)/1.8);
         expect(parsed.comment).to.eql('hXXb12345');

--- a/tests/WeatherParserUtilsTests.js
+++ b/tests/WeatherParserUtilsTests.js
@@ -6,7 +6,7 @@ const chai = require('chai');
 const expect = chai.expect;
 
 describe('WeatherParserUtils', () => {
-    it('Text regex & extract comment from weather', () => {
+    it('Extract weather and comment', () => {
         const parsed = WeatherParserUtils.parseWeatherData('g002t017r000p000P000h80b10232L016_COMMENT_AFTER');
         expect(parsed.weather).to.exist;
         expect(parsed.comment).to.exist;
@@ -48,19 +48,19 @@ describe('WeatherParserUtils', () => {
     });
 
     it('Negative temperature', () => {
-        const parsed = WeatherParserUtils.parseWeatherData('c...s...g...t-99Comment');
+        const parsed = WeatherParserUtils.parseWeatherData('s...g...t-99Comment');
         expect(parsed.weather.temperature).to.eql((-99-32)/1.8);
         expect(parsed.comment).to.eql('Comment');
     });
 
     it('Only temperature (irrelevant values replaced by spaces)', () => {
-        const parsed = WeatherParserUtils.parseWeatherData('c   s   g   t-99Comment');
+        const parsed = WeatherParserUtils.parseWeatherData('s   g   t-99Comment');
         expect(parsed.weather.temperature).to.eql((-99-32)/1.8);
         expect(parsed.comment).to.eql('Comment');
     });
 
     it('Invalid value stops parsing', () => {
-        const parsed = WeatherParserUtils.parseWeatherData('c...s...g...t-99hXXb12345');
+        const parsed = WeatherParserUtils.parseWeatherData('s...g...t-99hXXb12345');
         expect(parsed.weather.temperature).to.eql((-99-32)/1.8);
         expect(parsed.comment).to.eql('hXXb12345');
     });

--- a/tests/WeatherParserUtilsTests.js
+++ b/tests/WeatherParserUtilsTests.js
@@ -16,12 +16,12 @@ describe('WeatherParserUtils', () => {
         expect(parsed.weather.humidity).to.eql(80);
         expect(parsed.weather.luminosity).to.exist;
         expect(parsed.weather.luminosity).to.eql(16);
-        expect(parsed.weather.rain_1h).to.exist;
-        expect(parsed.weather.rain_1h).to.eql(0);
-        expect(parsed.weather.rain_24h).to.exist;
-        expect(parsed.weather.rain_24h).to.eql(0);
-        expect(parsed.weather.rain_since_midnight).to.exist;
-        expect(parsed.weather.rain_since_midnight).to.eql(0);
+        expect(parsed.weather.rain1h).to.exist;
+        expect(parsed.weather.rain1h).to.eql(0);
+        expect(parsed.weather.rain24h).to.exist;
+        expect(parsed.weather.rain24h).to.eql(0);
+        expect(parsed.weather.rainSinceMidnight).to.exist;
+        expect(parsed.weather.rainSinceMidnight).to.eql(0);
         expect(parsed.weather.temperature).to.exist;
         expect(parsed.weather.temperature).to.eql((17-32)/1.8);
         expect(parsed.comment).to.eql('_COMMENT_AFTER');
@@ -36,14 +36,32 @@ describe('WeatherParserUtils', () => {
         expect(parsed.weather.pressure).to.eql(993.3);
         expect(parsed.weather.humidity).to.exist;
         expect(parsed.weather.humidity).to.eql(90);
-        expect(parsed.weather.rain_1h).to.exist;
-        expect(parsed.weather.rain_1h).to.eql(3.048);
-        expect(parsed.weather.rain_24h).to.exist;
-        expect(parsed.weather.rain_24h).to.eql(10.414);
-        expect(parsed.weather.rain_since_midnight).to.exist;
-        expect(parsed.weather.rain_since_midnight).to.eql(10.414);
+        expect(parsed.weather.rain1h).to.exist;
+        expect(parsed.weather.rain1h).to.eql(3.048);
+        expect(parsed.weather.rain24h).to.exist;
+        expect(parsed.weather.rain24h).to.eql(10.414);
+        expect(parsed.weather.rainSinceMidnight).to.exist;
+        expect(parsed.weather.rainSinceMidnight).to.eql(10.414);
         expect(parsed.weather.temperature).to.exist;
         expect(parsed.weather.temperature).to.eql((36-32)/1.8);
         expect(parsed.comment).to.eql('eCumulusWS2300');
+    });
+
+    it('Negative temperature', () => {
+        const parsed = WeatherParserUtils.parseWeatherData('c...s...g...t-99Comment');
+        expect(parsed.weather.temperature).to.eql((-99-32)/1.8);
+        expect(parsed.comment).to.eql('Comment');
+    });
+
+    it("Only temperature (irrelevant values replaced by spaces)", () => {
+        const parsed = WeatherParserUtils.parseWeatherData('c   s   g   t-99Comment');
+        expect(parsed.weather.temperature).to.eql((-99-32)/1.8);
+        expect(parsed.comment).to.eql('Comment');
+    });
+
+    it("Invalid value stops parsing", () => {
+        const parsed = WeatherParserUtils.parseWeatherData('c...s...g...t-99hXXb12345');
+        expect(parsed.weather.temperature).to.eql((-99-32)/1.8);
+        expect(parsed.comment).to.eql('hXXb12345');
     });
 });

--- a/tests/WeatherParserUtilsTests.js
+++ b/tests/WeatherParserUtilsTests.js
@@ -7,11 +7,43 @@ const expect = chai.expect;
 
 describe('WeatherParserUtils', () => {
     it('Text regex & extract comment from weather', () => {
-        const parsed = WeatherParserUtils.parseWeatherData('COMMENT_BEFORE_g002t017r000p000P000h80b10232L016_COMMENT_AFTER');
+        const parsed = WeatherParserUtils.parseWeatherData('g002t017r000p000P000h80b10232L016_COMMENT_AFTER');
         expect(parsed.weather).to.exist;
         expect(parsed.comment).to.exist;
         expect(parsed.weather.pressure).to.exist;
         expect(parsed.weather.pressure).to.eql(1023.2);
-        expect(parsed.comment).to.eql('COMMENT_BEFORE__COMMENT_AFTER');
+        expect(parsed.weather.humidity).to.exist;
+        expect(parsed.weather.humidity).to.eql(80);
+        expect(parsed.weather.luminosity).to.exist;
+        expect(parsed.weather.luminosity).to.eql(16);
+        expect(parsed.weather.rain_1h).to.exist;
+        expect(parsed.weather.rain_1h).to.eql(0);
+        expect(parsed.weather.rain_24h).to.exist;
+        expect(parsed.weather.rain_24h).to.eql(0);
+        expect(parsed.weather.rain_since_midnight).to.exist;
+        expect(parsed.weather.rain_since_midnight).to.eql(0);
+        expect(parsed.weather.temperature).to.exist;
+        expect(parsed.weather.temperature).to.eql((17-32)/1.8);
+        expect(parsed.comment).to.eql('_COMMENT_AFTER');
+    });
+
+
+    it('Another weather string with rain', () => {
+        const parsed = WeatherParserUtils.parseWeatherData('g000t036r012p041P041h90b09933eCumulusWS2300');
+        expect(parsed.weather).to.exist;
+        expect(parsed.comment).to.exist;
+        expect(parsed.weather.pressure).to.exist;
+        expect(parsed.weather.pressure).to.eql(993.3);
+        expect(parsed.weather.humidity).to.exist;
+        expect(parsed.weather.humidity).to.eql(90);
+        expect(parsed.weather.rain_1h).to.exist;
+        expect(parsed.weather.rain_1h).to.eql(3.048);
+        expect(parsed.weather.rain_24h).to.exist;
+        expect(parsed.weather.rain_24h).to.eql(10.414);
+        expect(parsed.weather.rain_since_midnight).to.exist;
+        expect(parsed.weather.rain_since_midnight).to.eql(10.414);
+        expect(parsed.weather.temperature).to.exist;
+        expect(parsed.weather.temperature).to.eql((36-32)/1.8);
+        expect(parsed.comment).to.eql('eCumulusWS2300');
     });
 });

--- a/tests/WeatherParserUtilsTests.js
+++ b/tests/WeatherParserUtilsTests.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const WeatherParserUtils = require('../lib/Position/WeatherParserUtils.js');
+
+const chai = require('chai');
+const expect = chai.expect;
+
+describe('WeatherParserUtils', () => {
+    it('Text regex & extract comment from weather', () => {
+        const parsed = WeatherParserUtils.parseWeatherData('COMMENT_BEFORE_g002t017r000p000P000h80b10232L016_COMMENT_AFTER');
+        expect(parsed.weather).to.exist;
+        expect(parsed.comment).to.exist;
+        expect(parsed.weather.pressure).to.exist;
+        expect(parsed.weather.pressure).to.eql(1023.2);
+        expect(parsed.comment).to.eql('COMMENT_BEFORE__COMMENT_AFTER');
+    });
+});


### PR DESCRIPTION
- Removed wind speed and course from weather report, for reports with position wind is reported in speed/course extension. Wind speed is only in weather for position-less reports and they are out of scope of this PR (see http://www.aprs.org/aprs11/spec-wx.txt)
- Adjusted some value units
- Converted to parsing without regex