### PR TITLE
Filter ability for APRS-IS Connections

### DIFF
--- a/lib/APRSISConnector.js
+++ b/lib/APRSISConnector.js
@@ -7,7 +7,8 @@ const EventEmitter = require('events').EventEmitter;
 const APRSParser = require('./APRSParser');
 
 const APRSServer = 'rotate.aprs2.net';
-const APRSPort = 10152;
+const APRSUnfilteredPort = 10152;
+const APRSFilteredPort = 14580;
 
 function APRSISConnector() {
     const that = this;
@@ -31,7 +32,7 @@ function APRSISConnector() {
 APRSISConnector.constructor = APRSISConnector;
 APRSISConnector.prototype = Object.create(EventEmitter.prototype);
 
-APRSISConnector.prototype.connect = function (callsign) {
+APRSISConnector.prototype.connect = function (callsign, filter) {
     if (this.client) {
         this.disconnect();
     }
@@ -49,8 +50,17 @@ APRSISConnector.prototype.connect = function (callsign) {
             that.emit('raw', line);
     });
 
+    let connectString = 'user ' + callsign;
+    let APRSPort = APRSUnfilteredPort;
+
+    if (filter) {
+        connectString += ' filter ' + filter;
+        APRSPort = APRSFilteredPort;
+    }
+    connectString += '\n';
+
     that.client.connect(APRSPort, APRSServer, () => {
-        that.client.write('user ' + callsign + '\n');
+        that.client.write(connectString);
         that.emit('connected');
     });
 


### PR DESCRIPTION
Well now that I'm on a roll, I added ability to specify a [server-side filter](http://www.aprs-is.net/javAPRSFilter.aspx) when connecting to the APRS-IS server. This also involves switching from the unfiltered port (10152) to the filtered port (14580), but only of there's a filter active. Using the filtered port without specifying a filter results in no data, and the server won't accept a filter when connected to the unfiltered port.

I'm open to a cleaner way of building up the connectString inline instead of building it up in a variable.